### PR TITLE
feature: implement policy store removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.15.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
- "gimli 0.24.0",
+ "gimli 0.23.0",
 ]
 
 [[package]]
@@ -224,16 +224,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.59"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
+checksum = "88fb5a785d6b44fd9d6700935608639af1b8356de1e55d5f7c2740f4faa15d82"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.24.0",
+ "object 0.23.0",
  "rustc-demangle",
 ]
 
@@ -449,13 +449,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.1.1"
+name = "cpuid-bool"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
-dependencies = [
- "libc",
-]
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
@@ -1009,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glob"
@@ -1129,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
  "bytes 1.0.1",
  "http 0.2.4",
@@ -1140,9 +1137,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
 
 [[package]]
 name = "httpdate"
@@ -1201,7 +1198,7 @@ dependencies = [
  "futures-util",
  "h2 0.3.3",
  "http 0.2.4",
- "http-body 0.4.2",
+ "http-body 0.4.1",
  "httparse",
  "httpdate 1.0.0",
  "itoa",
@@ -1352,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1397,7 +1394,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "url 2.2.2",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -1442,7 +1439,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util 0.6.6",
  "tower",
- "url 2.2.2",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -1741,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "oci-distribution"
@@ -1760,7 +1757,7 @@ dependencies = [
  "reqwest 0.10.10",
  "serde",
  "serde_json",
- "sha2 0.9.4",
+ "sha2 0.9.3",
  "tokio 0.2.25",
  "www-authenticate",
 ]
@@ -1805,9 +1802,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "fa52160d45fa2e7608d504b7c3a3355afed615e6d8b627a74458634ba21b69bd"
 dependencies = [
  "autocfg",
  "cc",
@@ -1949,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "policy-fetcher"
 version = "0.1.0"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.6#f2ff41b51e05d46ea14fb74deaa30e1d41cca5ce"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.7#67490d8177fc2bfb22692cd7881b300791adf68f"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1964,7 +1961,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tokio-compat-02",
- "url 2.2.2",
+ "url 2.2.1",
  "walkdir",
 ]
 
@@ -2101,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "85dd92e586f7355c633911e11f77f3d12f04b1b1bd76a198bd34ae3af8341ef2"
 dependencies = [
  "bitflags",
 ]
@@ -2131,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2196,7 +2193,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio 0.2.25",
  "tokio-tls",
- "url 2.2.2",
+ "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2215,7 +2212,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.4",
- "http-body 0.4.2",
+ "http-body 0.4.1",
  "hyper 0.14.7",
  "hyper-tls 0.5.0",
  "ipnet",
@@ -2231,7 +2228,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio 1.5.0",
  "tokio-native-tls",
- "url 2.2.2",
+ "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2466,13 +2463,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f6b75b17576b792bef0db1bcc4b8b8bcdf9506744cf34b974195487af6cff2"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -2545,9 +2542,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2956,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna 0.2.3",
@@ -3084,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3096,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3111,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3123,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3133,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3146,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "wasmparser"
@@ -3404,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 clap = "2.33.3"
 directories = "3.0.2"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.2" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.6" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.7" }
 serde_json = "1.0"
 serde_yaml = "0.8.17"
 serde = { version = "1.0", features = ["derive"] }

--- a/e2e-tests/e2e.bats
+++ b/e2e-tests/e2e.bats
@@ -54,3 +54,19 @@ kwctl() {
     [ "$status" -eq 0 ]
     [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
 }
+
+@test "remove a policy from the policy store" {
+    kwctl pull registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.5
+    kwctl pull https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.5/policy.wasm
+    kwctl policies
+    [[ $(echo "$output" | wc -l) -eq 2 ]]
+    [[ ${lines[0]} =~ "registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.5" ]]
+    [[ ${lines[1]} =~ "https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.5/policy.wasm" ]]
+    kwctl rm registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.5
+    kwctl policies
+    [[ $(echo "$output" | wc -l) -eq 1 ]]
+    [[ ${lines[0]} =~ "https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.5/policy.wasm" ]]
+    kwctl rm https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.5/policy.wasm
+    kwctl policies
+    [ "$output" = "" ]
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use policy_fetcher::PullDestination;
 
 mod policies;
 mod pull;
+mod rm;
 mod run;
 
 #[tokio::main]
@@ -40,6 +41,10 @@ async fn main() -> Result<()> {
              (@arg ("sources-path"): --("sources-path") +takes_value "YAML file holding source information (https, registry insecure hosts, custom CA's...)")
              (@arg ("output-path"): -o --("output-path") +takes_value "Output file. If not provided will be downloaded to the Kubewarden store")
              (@arg ("uri"): * "Policy URI. Supported schemes: registry://, https://, file://")
+            )
+            (@subcommand rm =>
+             (about: "Removes a Kubewarden policy from the store")
+             (@arg ("uri"): * "Policy URI")
             )
             (@subcommand run =>
              (about: "Runs a Kubewarden policy from a given URI")
@@ -73,6 +78,13 @@ async fn main() -> Result<()> {
                 let (sources, docker_config) = pull_options(matches);
                 pull::pull(uri, docker_config, sources, destination).await?;
             };
+            Ok(())
+        }
+        Some("rm") => {
+            if let Some(ref matches) = matches.subcommand_matches("rm") {
+                let uri = matches.value_of("uri").unwrap();
+                rm::rm(uri)?;
+            }
             Ok(())
         }
         Some("run") => {

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -1,0 +1,41 @@
+use anyhow::{anyhow, Result};
+use std::path::PathBuf;
+
+pub(crate) fn rm(uri: &str) -> Result<()> {
+    let store = policy_fetcher::store::Store::default();
+    let policy_path =
+        store.policy_full_path(uri, policy_fetcher::store::PolicyPath::PrefixAndFilename)?;
+    std::fs::remove_file(&policy_path)
+        .map_err(|err| anyhow!("could not delete policy {}: {}", uri, err))?;
+
+    // Given a policy in the store, try to cleanup all intermediate
+    // directories up to the store root, from the innermost to the
+    // outermost. We don't care about errors: we just try to `rmdir`
+    // every directory up to the store root in reverse order to clean
+    // up as much as possible -- if possible.
+    {
+        let mut prefix = store.root.clone();
+        let policy_leading_store_components = policy_path
+            .iter()
+            .map(|component| {
+                prefix = prefix.join(component);
+                prefix.clone()
+            })
+            .collect::<Vec<PathBuf>>();
+
+        policy_leading_store_components
+            .iter()
+            .rev()
+            .skip(1) // policy name
+            .take(policy_leading_store_components.len() - store.root.components().count())
+            .for_each(|store_component| {
+                #[allow(unused_must_use)]
+                {
+                    // try to clean up empty dirs. Ignore errors.
+                    std::fs::remove_dir(store.root.join(&store_component));
+                }
+            });
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Implement the `rm` command that allows a user to remove a cached
policy, previously downloaded from an OCI registry or an HTTP server.

Fixes https://github.com/kubewarden/kwctl/issues/9