### PR TITLE
Metadata commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
 dependencies = [
- "gimli 0.23.0",
+ "gimli 0.24.0",
 ]
 
 [[package]]
@@ -224,16 +224,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88fb5a785d6b44fd9d6700935608639af1b8356de1e55d5f7c2740f4faa15d82"
+checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.23.0",
+ "object 0.24.0",
  "rustc-demangle",
 ]
 
@@ -449,10 +449,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
+name = "cpufeatures"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+checksum = "281f563b2c3a0e535ab12d81d3c5859045795256ad269afa7c19542585b68f93"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cranelift-bforest"
@@ -841,9 +844,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -856,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -866,15 +869,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -883,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
@@ -904,10 +907,11 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -916,22 +920,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1006,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "glob"
@@ -1126,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes 1.0.1",
  "http 0.2.4",
@@ -1137,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
@@ -1198,7 +1203,7 @@ dependencies = [
  "futures-util",
  "h2 0.3.3",
  "http 0.2.4",
- "http-body 0.4.1",
+ "http-body 0.4.2",
  "httparse",
  "httpdate 1.0.0",
  "itoa",
@@ -1267,6 +1272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1298,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7280c75fb2e2fc47080ec80ccc481376923acb04501957fc38f935c3de5088"
 
 [[package]]
 name = "indexmap"
@@ -1349,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1394,7 +1411,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "url 2.2.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -1439,17 +1456,19 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util 0.6.6",
  "tower",
- "url 2.2.1",
+ "url 2.2.2",
 ]
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a07292089c1ed973b2268c3601049b8af03d740829837c9fe2b9e158248d2"
+checksum = "fc979e2c4a5229e25ee16950c4473feb4da1570bc5d33cd4379a8cfbf952064a"
 dependencies = [
  "anyhow",
  "k8s-openapi",
+ "num-derive",
+ "num-traits",
  "serde",
  "serde_json",
  "wapc-guest",
@@ -1477,6 +1496,10 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tokio 1.5.0",
+ "url 2.2.2",
+ "validator",
+ "walrus",
+ "wasmparser 0.78.1",
 ]
 
 [[package]]
@@ -1691,6 +1714,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
 
 [[package]]
 name = "oci-distribution"
@@ -1757,7 +1791,7 @@ dependencies = [
  "reqwest 0.10.10",
  "serde",
  "serde_json",
- "sha2 0.9.3",
+ "sha2 0.9.5",
  "tokio 0.2.25",
  "www-authenticate",
 ]
@@ -1796,15 +1830,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.62"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52160d45fa2e7608d504b7c3a3355afed615e6d8b627a74458634ba21b69bd"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg",
  "cc",
@@ -1922,8 +1956,8 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.1.0"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.3#46b01aa009c1839645eecd6c0a1ee269068ca53d"
+version = "0.1.4"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.4#8a7aee1963194fc234fa460402bc661264726d7e"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -1935,18 +1969,18 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_json",
- "serde_yaml",
  "tokio 1.5.0",
  "tracing",
  "tracing-futures",
+ "validator",
  "wapc",
  "wasmtime-provider",
 ]
 
 [[package]]
 name = "policy-fetcher"
-version = "0.1.0"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.7#67490d8177fc2bfb22692cd7881b300791adf68f"
+version = "0.1.8"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.8#a4ad6d41e97cae3b7e5d4dddf18da743326beb47"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1961,7 +1995,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tokio-compat-02",
- "url 2.2.1",
+ "url 2.2.2",
  "walkdir",
 ]
 
@@ -1983,6 +2017,30 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check 0.9.3",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check 0.9.3",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -2098,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dd92e586f7355c633911e11f77f3d12f04b1b1bd76a198bd34ae3af8341ef2"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
@@ -2128,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2193,7 +2251,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio 0.2.25",
  "tokio-tls",
- "url 2.2.1",
+ "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2212,7 +2270,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.4",
- "http-body 0.4.1",
+ "http-body 0.4.2",
  "hyper 0.14.7",
  "hyper-tls 0.5.0",
  "ipnet",
@@ -2228,7 +2286,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio 1.5.0",
  "tokio-native-tls",
- "url 2.2.1",
+ "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2385,9 +2443,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
@@ -2404,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2463,13 +2521,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -2542,9 +2600,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2953,15 +3011,54 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
 ]
+
+[[package]]
+name = "validator"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be110dc66fa015b8b1d2c4eae40c495a27fae55f82b9cae3efb8178241ed20eb"
+dependencies = [
+ "idna 0.2.3",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url 2.2.2",
+ "validator_derive",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f14fe757e2894ce4271991901567be07fbc3eac6b24246122214e1d5a16554"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
 
 [[package]]
 name = "value-bag"
@@ -3011,6 +3108,32 @@ dependencies = [
  "same-file",
  "winapi 0.3.9",
  "winapi-util",
+]
+
+[[package]]
+name = "walrus"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb08e48cde54c05f363d984bb54ce374f49e242def9468d2e1b6c2372d291f8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasmparser 0.77.0",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3081,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3093,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3108,9 +3231,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3120,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3130,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3143,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "wasmparser"
@@ -3158,6 +3281,18 @@ name = "wasmparser"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
+
+[[package]]
+name = "wasmparser"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
+
+[[package]]
+name = "wasmparser"
+version = "0.78.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9255225d0124a59dd44def5cf98b62d70a27aed921f2c51e28035f08a73b0c"
 
 [[package]]
 name = "wasmtime"
@@ -3401,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,13 @@ edition = "2018"
 anyhow = "1.0"
 clap = "2.33.3"
 directories = "3.0.2"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.3" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.7" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.4" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.8" }
 serde_json = "1.0"
-serde_yaml = "0.8.17"
 serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8.17"
 tokio = { version = "^1", features = ["full"] }
+url = "2.2.0"
+validator = { version = "0.13", features = ["derive"] }
+walrus = "0.19.0"
+wasmparser = "0.78.0"

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,0 +1,55 @@
+use anyhow::{anyhow, Result};
+use std::fs::File;
+use std::path::PathBuf;
+use validator::Validate;
+
+use policy_evaluator::policy_evaluator::PolicyEvaluator;
+use policy_evaluator::policy_metadata::Metadata;
+
+use crate::constants::KUBEWARDEN_CUSTOM_SECTION_METADATA;
+
+pub(crate) fn write_annotation(
+    wasm_path: PathBuf,
+    metadata_path: PathBuf,
+    destination: PathBuf,
+) -> Result<()> {
+    let metadata = prepare_metadata(wasm_path.clone(), metadata_path)?;
+    write_annotated_wasm_file(wasm_path, destination, metadata)
+}
+
+fn prepare_metadata(wasm_path: PathBuf, metadata_path: PathBuf) -> Result<Metadata> {
+    let metadata_file = File::open(metadata_path)?;
+    let mut metadata: Metadata = serde_yaml::from_reader(&metadata_file)?;
+
+    let policy_evaluator = PolicyEvaluator::new(wasm_path.as_path(), None)?;
+    let protocol_version = policy_evaluator
+        .protocol_version()
+        .map_err(|e| anyhow!("Cannot compute ProtocolVersion used by the policy: {:?}", e))?;
+
+    metadata.protocol_version = Some(protocol_version);
+
+    metadata
+        .validate()
+        .map_err(|e| anyhow!("Metadata is invalid: {:?}", e))
+        .and(Ok(metadata))
+}
+
+fn write_annotated_wasm_file(
+    input_path: PathBuf,
+    output_path: PathBuf,
+    metadata: Metadata,
+) -> Result<()> {
+    let buf: Vec<u8> = std::fs::read(input_path)?;
+    let metadata_json = serde_json::to_vec(&metadata)?;
+
+    let mut module = walrus::Module::from_buffer(buf.as_slice())?;
+
+    let custom_section = walrus::RawCustomSection {
+        name: String::from(KUBEWARDEN_CUSTOM_SECTION_METADATA),
+        data: metadata_json,
+    };
+    module.customs.add(custom_section);
+
+    module.emit_wasm_file(output_path)?;
+    Ok(())
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,1 @@
+pub(crate) const KUBEWARDEN_CUSTOM_SECTION_METADATA: &str = "io.kubewarden.metadata";

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,0 +1,59 @@
+use anyhow::{anyhow, Result};
+use std::path::PathBuf;
+use url::Url;
+use wasmparser::{Parser, Payload};
+
+use policy_evaluator::policy_metadata::Metadata;
+use policy_fetcher::store::Store;
+
+use crate::constants::KUBEWARDEN_CUSTOM_SECTION_METADATA;
+
+pub(crate) fn inspect(uri: &str) -> Result<()> {
+    let url = Url::parse(uri)?;
+    let wasm_path = match url.scheme() {
+        "file" => url
+            .to_file_path()
+            .map_err(|err| anyhow!("cannot retrieve path from uri {}: {:?}", url, err)),
+        "http" | "https" | "registry" => {
+            let policies = Store::default().list()?;
+            let policy = policies.iter().find(|policy| policy.uri == uri).ok_or_else(|| anyhow!("Cannot find policy '{uri}' inside of the local store.\nTry executing `kwctl pull {uri}`", uri = uri))?;
+            Ok(policy.local_path.clone())
+        }
+        _ => Err(anyhow!("unknown scheme: {}", url.scheme())),
+    }?;
+
+    match get_metadata(wasm_path)? {
+        Some(metadata) => {
+            let metadata_yaml = serde_yaml::to_string(&metadata)?;
+            println!("Metadata:\n{}", metadata_yaml);
+            Ok(())
+        }
+        None => Err(anyhow!(
+            "No Kubewarden metadata found inside of '{}'.\nPolicies can be annotated with the `kwctl annotate` command.",
+            uri
+        )),
+    }
+}
+
+fn get_metadata(wasm_path: PathBuf) -> Result<Option<Metadata>> {
+    let mut result: Option<Metadata> = None;
+    let buf: Vec<u8> = std::fs::read(wasm_path)?;
+    for payload in Parser::new(0).parse_all(&buf) {
+        match payload? {
+            Payload::CustomSection {
+                name,
+                data,
+                data_offset: _,
+                range: _,
+            } => {
+                if name == KUBEWARDEN_CUSTOM_SECTION_METADATA {
+                    let metadata: Metadata = serde_json::from_slice(data)?;
+                    result = Some(metadata);
+                }
+            }
+            _other => {}
+        }
+    }
+
+    Ok(result)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use policy_fetcher::sources::{read_sources_file, Sources};
 use policy_fetcher::store::DEFAULT_ROOT;
 use policy_fetcher::PullDestination;
 
+mod constants;
 mod policies;
 mod pull;
 mod rm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use policy_fetcher::PullDestination;
 
 mod annotate;
 mod constants;
+mod inspect;
 mod policies;
 mod pull;
 mod rm;
@@ -61,6 +62,10 @@ async fn main() -> Result<()> {
              (@arg ("metadata-path"): * -m --("metadata-path") +takes_value "File containing the metadata")
              (@arg ("wasm-path"): * "Path to WebAssembly module to be annotated")
              (@arg ("output-path"): * -o --("output-path") +takes_value "Output file")
+            )
+            (@subcommand inspect =>
+             (about: "Inspect Kubewarden policy")
+             (@arg ("uri"): * "Policy URI. Supported schemes: registry://, https://, file://")
             )
 
     )
@@ -125,6 +130,13 @@ async fn main() -> Result<()> {
                     .unwrap();
                 annotate::write_annotation(wasm_path, metadata_file, destination)?;
             }
+            Ok(())
+        }
+        Some("inspect") => {
+            if let Some(ref matches) = matches.subcommand_matches("inspect") {
+                let uri = matches.value_of("uri").unwrap();
+                inspect::inspect(uri)?;
+            };
             Ok(())
         }
         Some(command) => Err(anyhow!("unknown subcommand: {}", command)),


### PR DESCRIPTION
Introduce the `annotate` and the `inspect` commands.

Fixes https://github.com/kubewarden/kwctl/issues/8

## Annotate

```console
$ kwctl annotate
           -m ../psp-apparmor/metadata.yml \
           -o annotated.wasm \
           ../psp-apparmor/target/wasm32-unknown-unknown/release/psp_apparmor.wasm
```

This command reads the user-provided metadata file, reads a vanilla Wasm file and produces a Wasm file that has the metadata embedded as a custom Wasm section.

## Inspect

```console
$ kwctl inspect file:///home/flavio/hacking/kubernetes/kubewarden/kwctl/annotated.wasm
Metadata:
---
protocolVersion: v1
rules:
  - apiGroups:
      - ""
    apiVersions:
      - v1
    resources:
      - pods
    operations:
      - CREATE
      - UPDATE
labels:
  io.kubewarden.policy.url: "https://github.com/chimera-kube/psp-apparmor"
  io.kubewarden.policy.license: Apache-2.0
  io.kubewarden.policy.source: "https://github.com/chimera-kube/psp-apparmor"
  io.kubewarden.policy.author: Flavio Castelli
```

This command dumps the metadata stored inside of a policy to the stdout.

The command works also with policies that are inside of the main store, plus it handles policies that do not have metadata:

```console
$ kwctl inspect 'registry://ghcr.io/kubewarden/policies/psp-apparmor:v0.1.3'`
Error: No Kubewarden metadata found inside of 'registry://ghcr.io/kubewarden/policies/psp-apparmor:v0.1.3'.
Policies can be annotated with the `kwctl annotate` command.
```
