### PR TITLE
Add `manifest` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,7 @@ dependencies = [
  "anyhow",
  "clap",
  "directories 3.0.2",
+ "k8s-openapi",
  "policy-evaluator",
  "policy-fetcher",
  "serde",
@@ -1957,8 +1958,8 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.1.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.4#8a7aee1963194fc234fa460402bc661264726d7e"
+version = "0.1.5"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.5#b6a846fe692b4bed7a03b2cc5dac1e0236d93c2f"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,13 @@ edition = "2018"
 anyhow = "1.0"
 clap = "2.33.3"
 directories = "3.0.2"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.4" }
+k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.5" }
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.9" }
-tokio-compat-02 = "0.2.0"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.17"
+tokio-compat-02 = "0.2.0"
 tokio = { version = "^1", features = ["full"] }
 url = "2.2.0"
 validator = { version = "0.13", features = ["derive"] }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,28 +1,9 @@
 use anyhow::{anyhow, Result};
-use std::path::PathBuf;
-use url::Url;
-use wasmparser::{Parser, Payload};
-
-use policy_evaluator::policy_metadata::Metadata;
-use policy_fetcher::store::Store;
-
-use crate::constants::KUBEWARDEN_CUSTOM_SECTION_METADATA;
 
 pub(crate) fn inspect(uri: &str) -> Result<()> {
-    let url = Url::parse(uri)?;
-    let wasm_path = match url.scheme() {
-        "file" => url
-            .to_file_path()
-            .map_err(|err| anyhow!("cannot retrieve path from uri {}: {:?}", url, err)),
-        "http" | "https" | "registry" => {
-            let policies = Store::default().list()?;
-            let policy = policies.iter().find(|policy| policy.uri == uri).ok_or_else(|| anyhow!("Cannot find policy '{uri}' inside of the local store.\nTry executing `kwctl pull {uri}`", uri = uri))?;
-            Ok(policy.local_path.clone())
-        }
-        _ => Err(anyhow!("unknown scheme: {}", url.scheme())),
-    }?;
+    let wasm_path = crate::utils::wasm_path(uri)?;
 
-    match get_metadata(wasm_path)? {
+    match crate::metadata::get_metadata(wasm_path)? {
         Some(metadata) => {
             let metadata_yaml = serde_yaml::to_string(&metadata)?;
             println!("Metadata:\n{}", metadata_yaml);
@@ -33,27 +14,4 @@ pub(crate) fn inspect(uri: &str) -> Result<()> {
             uri
         )),
     }
-}
-
-fn get_metadata(wasm_path: PathBuf) -> Result<Option<Metadata>> {
-    let mut result: Option<Metadata> = None;
-    let buf: Vec<u8> = std::fs::read(wasm_path)?;
-    for payload in Parser::new(0).parse_all(&buf) {
-        match payload? {
-            Payload::CustomSection {
-                name,
-                data,
-                data_offset: _,
-                range: _,
-            } => {
-                if name == KUBEWARDEN_CUSTOM_SECTION_METADATA {
-                    let metadata: Metadata = serde_json::from_slice(data)?;
-                    result = Some(metadata);
-                }
-            }
-            _other => {}
-        }
-    }
-
-    Ok(result)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use policy_fetcher::PullDestination;
 mod annotate;
 mod constants;
 mod inspect;
+mod manifest;
 mod metadata;
 mod policies;
 mod pull;
@@ -75,6 +76,11 @@ async fn main() -> Result<()> {
             )
             (@subcommand inspect =>
              (about: "Inspect Kubewarden policy")
+             (@arg ("uri"): * "Policy URI. Supported schemes: registry://, https://, file://")
+            )
+            (@subcommand manifest =>
+             (about: "Scaffold a Kubernetes resource")
+             (@arg ("type"): * -t --("type") +takes_value "Kubewarden Custom Resource type. Valid values: ClusterAdmissionPolicy")
              (@arg ("uri"): * "Policy URI. Supported schemes: registry://, https://, file://")
             )
 
@@ -155,6 +161,14 @@ async fn main() -> Result<()> {
             if let Some(ref matches) = matches.subcommand_matches("inspect") {
                 let uri = matches.value_of("uri").unwrap();
                 inspect::inspect(uri)?;
+            };
+            Ok(())
+        }
+        Some("manifest") => {
+            if let Some(ref matches) = matches.subcommand_matches("manifest") {
+                let uri = matches.value_of("uri").unwrap();
+                let resource_type = matches.value_of("type").unwrap();
+                manifest::manifest(uri, resource_type)?;
             };
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,13 @@ use policy_fetcher::PullDestination;
 mod annotate;
 mod constants;
 mod inspect;
+mod metadata;
 mod policies;
 mod pull;
 mod push;
 mod rm;
 mod run;
+mod utils;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,78 @@
+use anyhow::{anyhow, Result};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use validator::Validate;
+
+use policy_evaluator::policy_metadata::{Metadata, Rule};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ClusterAdmissionPolicy {
+    api_version: String,
+    kind: String,
+    metadata: ObjectMeta,
+    spec: ClusterAdmissionPolicySpec,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ClusterAdmissionPolicySpec {
+    module: String,
+    settings: serde_yaml::Mapping,
+    rules: Vec<Rule>,
+    mutating: bool,
+}
+
+impl TryFrom<ScaffoldData> for ClusterAdmissionPolicy {
+    type Error = anyhow::Error;
+
+    fn try_from(data: ScaffoldData) -> Result<Self, Self::Error> {
+        data.metadata.validate()?;
+        Ok(ClusterAdmissionPolicy {
+            api_version: String::from("policies.kubewarden.io/v1alpha2"),
+            kind: String::from("ClusterAdmissionPolicy"),
+            metadata: ObjectMeta {
+                name: Some(String::from("generated-policy")),
+                ..Default::default()
+            },
+            spec: ClusterAdmissionPolicySpec {
+                module: data.uri,
+                settings: serde_yaml::Mapping::new(),
+                rules: data.metadata.rules.clone(),
+                mutating: data.metadata.mutating,
+            },
+        })
+    }
+}
+
+struct ScaffoldData {
+    pub uri: String,
+    metadata: Metadata,
+}
+
+pub(crate) fn manifest(uri: &str, resource_type: &str) -> Result<()> {
+    let wasm_path = crate::utils::wasm_path(uri)?;
+    let metadata = crate::metadata::get_metadata(wasm_path)?
+        .ok_or_else(||
+            anyhow!(
+                "No Kubewarden metadata found inside of '{}'.\nPolicies can be annotated with the `kwctl annotate` command.",
+                uri)
+        )?;
+    let scaffold_data = ScaffoldData {
+        uri: String::from(uri),
+        metadata,
+    };
+    let resource = match resource_type {
+        "ClusterAdmissionPolicy" => ClusterAdmissionPolicy::try_from(scaffold_data),
+        _other => Err(anyhow!(
+            "Resource {} unknown. Valid types are: ClusterAdmissionPolicy"
+        )),
+    }?;
+
+    let stdout = std::io::stdout();
+    let out = stdout.lock();
+    serde_yaml::to_writer(out, &resource)?;
+
+    Ok(())
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use policy_evaluator::policy_metadata::Metadata;
+use std::path::PathBuf;
+use wasmparser::{Parser, Payload};
+
+use crate::constants::KUBEWARDEN_CUSTOM_SECTION_METADATA;
+
+pub(crate) fn get_metadata(wasm_path: PathBuf) -> Result<Option<Metadata>> {
+    let mut result: Option<Metadata> = None;
+    let buf: Vec<u8> = std::fs::read(wasm_path)?;
+    for payload in Parser::new(0).parse_all(&buf) {
+        match payload? {
+            Payload::CustomSection {
+                name,
+                data,
+                data_offset: _,
+                range: _,
+            } => {
+                if name == KUBEWARDEN_CUSTOM_SECTION_METADATA {
+                    let metadata: Metadata = serde_json::from_slice(data)?;
+                    result = Some(metadata);
+                }
+            }
+            _other => {}
+        }
+    }
+
+    Ok(result)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,19 @@
+use anyhow::{anyhow, Result};
+use policy_fetcher::store::Store;
+use std::path::PathBuf;
+use url::Url;
+
+pub(crate) fn wasm_path(uri: &str) -> Result<PathBuf> {
+    let url = Url::parse(uri)?;
+    match url.scheme() {
+        "file" => url
+            .to_file_path()
+            .map_err(|err| anyhow!("cannot retrieve path from uri {}: {:?}", url, err)),
+        "http" | "https" | "registry" => {
+            let policies = Store::default().list()?;
+            let policy = policies.iter().find(|policy| policy.uri == uri).ok_or_else(|| anyhow!("Cannot find policy '{uri}' inside of the local store.\nTry executing `kwctl pull {uri}`", uri = uri))?;
+            Ok(policy.local_path.clone())
+        }
+        _ => Err(anyhow!("unknown scheme: {}", url.scheme())),
+    }
+}


### PR DESCRIPTION
This PR introduces the new `manifest` command. This command uses the metadata embedded into the policy to generate a [ClusterAdmissionPolicy](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/ClusterAdmissionPolicy/v1alpha1@v0.1.0) resource.

Example of usage:

```console
$ kwctl manifest 'file:///home/flavio/hacking/kubernetes/kubewarden/kwctl/annotated.wasm' --type ClusterAdmissionPolicy`
---
apiVersion: policies.kubewarden.io/v1alpha2
kind: ClusterAdmissionPolicy
metadata:
  name: generated-policy
spec:
  module: "file:///home/flavio/hacking/kubernetes/kubewarden/kwctl/annotated.wasm"
  settings: {}
  rules:
    - apiGroups:
        - ""
      apiVersions:
        - v1
      resources:
        - pod
      operations:
        - CREATE
        - UPDATE
  mutating: false
```

**Note well:**
* The output produced by this command is not meant to be piped directly into `kubectl`. The user has to tune it a little. For example, we are deliberately not handling the policy settings
* We are generating a `ClusterAdmissionPolicy` with version set to `policies.kubewarden.io/v1alpha2`. This version doesn't yet exist, a new PR will introduce it. 