### PR TITLE
Improve readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,7 +448,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -1590,6 +1599,9 @@ dependencies = [
  "sha2 0.9.5",
  "tokio 1.6.0",
  "tokio-compat-02",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
  "url 2.2.2",
  "validator",
  "walrus",
@@ -1651,6 +1663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2338,6 +2359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2690,6 +2712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,6 +2864,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -3083,6 +3123,49 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ serde_yaml = "0.8.17"
 sha2 = "0.9.5"
 tokio-compat-02 = "0.2.0"
 tokio = { version = "^1", features = ["full"] }
+tracing = "0.1"
+tracing-futures = "0.2"
+tracing-subscriber = { version= "0.2", features = ["fmt"] }
 url = "2.2.0"
 validator = { version = "0.13", features = ["derive"] }
 walrus = "0.19.0"

--- a/src/run.rs
+++ b/src/run.rs
@@ -21,34 +21,25 @@ pub(crate) async fn pull_and_run(
     .map_err(|e| anyhow!("Error pulling policy {}: {}", uri, e))?;
 
     let request = serde_json::from_str::<serde_json::Value>(&request)?;
+    let policy_evaluator = PolicyEvaluator::new(
+        policy_path.as_path(),
+        settings.map_or(Ok(None), |settings| serde_yaml::from_str(&settings))?,
+    )?;
+    let req_obj = match request {
+        serde_json::Value::Object(ref object) => {
+            if object.get("kind").and_then(serde_json::Value::as_str) == Some("AdmissionReview") {
+                object
+                    .get("request")
+                    .ok_or_else(|| anyhow!("invalid admission review object"))
+            } else {
+                Ok(&request)
+            }
+        }
+        _ => Err(anyhow!("request to evaluate is invalid")),
+    }?;
 
-    println!(
-        "{}",
-        serde_json::to_string(
-            &PolicyEvaluator::new(
-                policy_path.as_path(),
-                settings.map_or(Ok(None), |settings| serde_yaml::from_str(&settings))?,
-            )?
-            .validate(
-                {
-                    match request {
-                        serde_json::Value::Object(ref object) => {
-                            if object.get("kind").and_then(serde_json::Value::as_str)
-                                == Some("AdmissionReview")
-                            {
-                                object
-                                    .get("request")
-                                    .ok_or_else(|| anyhow!("invalid admission review object"))
-                            } else {
-                                Ok(&request)
-                            }
-                        }
-                        _ => Err(anyhow!("request to evaluate is invalid")),
-                    }
-                }?
-                .clone()
-            )
-        )?
-    );
+    let response = policy_evaluator.validate(req_obj.clone());
+    println!("{}", serde_json::to_string(&response)?);
+
     Ok(())
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -17,7 +17,8 @@ pub(crate) async fn pull_and_run(
         sources,
         policy_fetcher::PullDestination::MainStore,
     )
-    .await?;
+    .await
+    .map_err(|e| anyhow!("Error pulling policy {}: {}", uri, e))?;
 
     let request = serde_json::from_str::<serde_json::Value>(&request)?;
 


### PR DESCRIPTION
Split the `run` code into smaller units. IMHO that improves readability and allows for better handling of the errors (if we want to).

Note well: this is build on top of https://github.com/kubewarden/kwctl/pull/26/