### PR TITLE
feat: allow to skip scheme on `kwctl run` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ dependencies = [
  "policy-fetcher",
  "pretty-bytes",
  "prettytable-rs",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2070,8 +2071,8 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.1.6"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.8#582da8d38d5eba338de5e747b36feec3d0505491"
+version = "0.1.9"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.9#0f60db0474741a24d8e67544c30bf5cc6edc246a"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.9" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
+regex = "1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.17"

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
              (@arg ("sources-path"): --("sources-path") +takes_value "YAML file holding source information (https, registry insecure hosts, custom CA's...)")
              (@arg ("request-path"): * -r --("request-path") +takes_value "File containing the Kubernetes admission request object in JSON format")
              (@arg ("settings-path"): -s --("settings-path") +takes_value "File containing the settings for this policy")
-             (@arg ("uri"): * "Policy URI. Supported schemes: registry://, https://, file://")
+             (@arg ("uri"): * "Policy URI. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory")
             )
             (@subcommand annotate =>
              (about: "Add Kubewarden metadata to a WebAssembly module")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,27 @@
 use anyhow::{anyhow, Result};
 use policy_fetcher::store::Store;
-use std::path::PathBuf;
+use regex::Regex;
+use std::{env, path::PathBuf};
 use url::Url;
+
+pub(crate) fn map_path_to_uri(uri: &str) -> Result<String> {
+    let uri_has_schema = Regex::new(r"^\w+://").unwrap();
+    if uri_has_schema.is_match(uri) {
+        return Ok(String::from(uri));
+    }
+    if PathBuf::from(uri).is_absolute() {
+        Ok(format!("file://{}", uri))
+    } else {
+        Ok(format!(
+            "file://{}/{}",
+            env::current_dir()?
+                .into_os_string()
+                .into_string()
+                .map_err(|err| anyhow!("invalid path: {:?}", err))?,
+            uri
+        ))
+    }
+}
 
 pub(crate) fn wasm_path(uri: &str) -> Result<PathBuf> {
     let url = Url::parse(uri)?;
@@ -15,5 +35,52 @@ pub(crate) fn wasm_path(uri: &str) -> Result<PathBuf> {
             Ok(policy.local_path.clone())
         }
         _ => Err(anyhow!("unknown scheme: {}", url.scheme())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_path_to_uri_remote_scheme() -> Result<()> {
+        assert_eq!(
+            map_path_to_uri("registry://some-registry.com/some-path/some-policy:0.0.1")?,
+            String::from("registry://some-registry.com/some-path/some-policy:0.0.1"),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_map_path_to_uri_missing_scheme() -> Result<()> {
+        assert_eq!(
+            map_path_to_uri("some-policy-0.0.1.wasm")?,
+            format!(
+                "file://{}",
+                env::current_dir()?
+                    .join("some-policy-0.0.1.wasm")
+                    .into_os_string()
+                    .into_string()
+                    .map_err(|_| anyhow!("cannot get policy test path"))?,
+            ),
+        );
+
+        assert_eq!(
+            map_path_to_uri("/absolute/directory/some-policy-0.0.1.wasm")?,
+            "file:///absolute/directory/some-policy-0.0.1.wasm",
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_map_path_to_uri_local_scheme() -> Result<()> {
+        assert_eq!(
+            map_path_to_uri("file:///absolute/directory/some-policy-0.0.1.wasm")?,
+            "file:///absolute/directory/some-policy-0.0.1.wasm",
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
If `kwctl run` command is called with a module without a scheme,
assume the `file://` scheme, rooted on the local directory. This way,
it's possible to run modules in the following ways:

- `kwctl run registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.2 -s <settings> -r <request>`
- `kwctl run file://$(pwd)/safe-labels.wasm -s <settings> -r <request>`
- `kwctl run safe-labels.wasm -s <settings> -r <request>`