### PR TITLE
Introduce "pretty" inspect output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +259,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object 0.24.0",
  "rustc-demangle",
 ]
@@ -287,6 +293,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -374,6 +395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytemuck"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +489,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "concurrent-queue"
@@ -695,6 +734,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+dependencies = [
+ "adler32",
+ "byteorder",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +864,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_proxy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
+dependencies = [
+ "log",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,12 +913,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fancy-regex"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae91abf6555234338687bb47913978d275539235fcb77ba9863b779090b42b14"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fehler"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5729fe49ba028cd550747b6e62cd3d841beccab5390aa398538c31a2d983635"
+dependencies = [
+ "fehler-macros",
+]
+
+[[package]]
+name = "fehler-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb5acb1045ebbfa222e2c50679e392a71dd77030b78fb0189f2d9c5974400f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -882,6 +971,18 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.8",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide 0.4.4",
 ]
 
 [[package]]
@@ -1066,6 +1167,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1205,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gif"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a668f699973d0f573d15749b7002a9ac9e1f9c6b220e7b165601334c173d8de"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -1404,6 +1525,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f7280c75fb2e2fc47080ec80ccc481376923acb04501957fc38f935c3de5088"
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif",
+ "jpeg-decoder",
+ "num-iter",
+ "num-rational 0.3.2",
+ "num-traits",
+ "png",
+ "scoped_threadpool",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1600,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
+dependencies = [
+ "rayon",
 ]
 
 [[package]]
@@ -1559,12 +1708,13 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc979e2c4a5229e25ee16950c4473feb4da1570bc5d33cd4379a8cfbf952064a"
+checksum = "23e8d71498a7ffad69a26cabb39715e490fba2a6878e96fae87cef283f2ff74a"
 dependencies = [
  "anyhow",
  "k8s-openapi",
+ "num",
  "num-derive",
  "num-traits",
  "serde",
@@ -1589,15 +1739,19 @@ dependencies = [
  "clap",
  "directories 3.0.2",
  "k8s-openapi",
+ "kubewarden-policy-sdk",
+ "mdcat",
  "policy-evaluator",
  "policy-fetcher",
  "pretty-bytes",
  "prettytable-rs",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.9.5",
+ "syntect",
  "tokio 1.6.0",
  "tokio-compat-02",
  "tracing",
@@ -1621,6 +1775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1791,15 @@ name = "libc"
 version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+
+[[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1682,6 +1851,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "mdcat"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60e7837c24e0df8dd9fca60763c1f7dcc9827f4b5d62193d04244dee7e0a07"
+dependencies = [
+ "ansi_term 0.12.1",
+ "anyhow",
+ "base64 0.13.0",
+ "clap",
+ "env_proxy",
+ "fehler",
+ "gethostname",
+ "image",
+ "libc",
+ "mime",
+ "pulldown-cmark",
+ "shell-words",
+ "syntect",
+ "terminal_size",
+ "ureq",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1912,15 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
  "unicase 2.6.0",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -1829,6 +2031,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.4.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +2082,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1916,6 +2186,28 @@ name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "onig"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b46fd9edbc018f0be4e366c24c46db44fac49cd01c039ae85308088b089dd5"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "libc",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed063c96cf4c0f2e5d09324409d158b38a0a85a7b90fbd68c8cad75c495d5775"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -2070,9 +2362,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "plist"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679104537029ed2287c216bfb942bbf723f48ee98f0aef15611634173a74ef21"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "indexmap",
+ "line-wrap",
+ "serde",
+ "xml-rs",
+]
+
+[[package]]
+name = "png"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate",
+ "miniz_oxide 0.3.7",
+]
+
+[[package]]
 name = "policy-evaluator"
-version = "0.1.9"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.9#0f60db0474741a24d8e67544c30bf5cc6edc246a"
+version = "0.1.10"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.10#8c3924accf78710acf55de525535a2cba2234598"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -2202,6 +2520,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -2523,10 +2852,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -2546,6 +2893,12 @@ dependencies = [
  "lazy_static",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "scopeguard"
@@ -2722,6 +3075,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +3158,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfac2b23b4d049dc9a89353b4e06bbc85a8f42020cccbe5409a115cf19031e5"
+dependencies = [
+ "bincode",
+ "bitflags",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "lazy_static",
+ "lazycell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +3221,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,6 +3266,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tiff"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
+dependencies = [
+ "jpeg-decoder",
+ "miniz_oxide 0.4.4",
+ "weezl",
 ]
 
 [[package]]
@@ -3249,6 +3652,23 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2475a6781e9bc546e7b64f4013d2f4032c8c6a40fcffd7c6f4ee734a890972ab"
+dependencies = [
+ "base64 0.13.0",
+ "chunked_transfer",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "url 2.2.2",
+ "webpki",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"
@@ -3807,6 +4227,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e"
+
+[[package]]
 name = "wepoll-sys"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3960,6 +4395,12 @@ dependencies = [
  "unicase 1.4.2",
  "url 1.7.2",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,19 @@ anyhow = "1.0"
 clap = "2.33.3"
 directories = "3.0.2"
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.9" }
+kubewarden-policy-sdk = "0.2.2"
+mdcat = "0.22"
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.10" }
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.9" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
+pulldown-cmark = { version = "0.8", default-features = false }
 regex = "1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.17"
 sha2 = "0.9.5"
+syntect = "4.5.0"
 tokio-compat-02 = "0.2.0"
 tokio = { version = "^1", features = ["full"] }
 tracing = "0.1"

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,18 +1,197 @@
-use anyhow::{anyhow, Result};
-use policy_evaluator::policy_metadata::Metadata;
+use std::convert::TryFrom;
 
-pub(crate) fn inspect(uri: &str) -> Result<()> {
+use anyhow::{anyhow, Result};
+use kubewarden_policy_sdk::metadata::ProtocolVersion;
+use mdcat::{ResourceAccess, TerminalCapabilities, TerminalSize};
+use policy_evaluator::policy_metadata::Metadata;
+use prettytable::{format::FormatBuilder, Table};
+use pulldown_cmark::{Options, Parser};
+use syntect::parsing::SyntaxSet;
+
+pub(crate) fn inspect(uri: &str, output: Option<&str>) -> Result<()> {
     let wasm_path = crate::utils::wasm_path(uri)?;
+    let printer = get_printer(OutputType::try_from(output)?);
 
     match Metadata::from_path(&wasm_path)? {
-        Some(metadata) => {
-            let metadata_yaml = serde_yaml::to_string(&metadata)?;
-            println!("Metadata:\n{}", metadata_yaml);
-            Ok(())
-        }
+        Some(metadata) => printer.print(&metadata),
         None => Err(anyhow!(
             "No Kubewarden metadata found inside of '{}'.\nPolicies can be annotated with the `kwctl annotate` command.",
             uri
         )),
+    }
+}
+
+enum OutputType {
+    Yaml,
+    Pretty,
+}
+
+impl TryFrom<Option<&str>> for OutputType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Option<&str>) -> Result<Self, Self::Error> {
+        match value {
+            Some("yaml") => Ok(Self::Yaml),
+            None => Ok(Self::Pretty),
+            Some(unknown) => Err(anyhow!("Invalid output format '{}'", unknown)),
+        }
+    }
+}
+
+fn get_printer(output_type: OutputType) -> Box<dyn MetadataPrinter> {
+    match output_type {
+        OutputType::Yaml => Box::new(MetadataYamlPrinter {}),
+        OutputType::Pretty => Box::new(MetadataPrettyPrinter {}),
+    }
+}
+
+trait MetadataPrinter {
+    fn print(&self, metadata: &Metadata) -> Result<()>;
+}
+
+struct MetadataYamlPrinter {}
+
+impl MetadataPrinter for MetadataYamlPrinter {
+    fn print(&self, metadata: &Metadata) -> Result<()> {
+        let metadata_yaml = serde_yaml::to_string(&metadata)?;
+        println!("{}", metadata_yaml);
+        Ok(())
+    }
+}
+
+struct MetadataPrettyPrinter {}
+
+impl MetadataPrettyPrinter {
+    fn annotation_to_row_key(&self, text: &str) -> String {
+        let mut out = String::from(text);
+        out.push(':');
+        String::from(out.trim_start_matches("io.kubewarden.policy."))
+    }
+
+    fn print_metadata_generic_info(&self, metadata: &Metadata) -> Result<()> {
+        let protocol_version = metadata
+            .protocol_version
+            .clone()
+            .ok_or_else(|| anyhow!("Invalid policy: protocol_version not defined"))?;
+        if protocol_version == ProtocolVersion::Unknown {
+            return Err(anyhow!("Invalid policy: protocol_version not defined"));
+        }
+
+        let pretty_annotations = vec![
+            "io.kubewarden.policy.title",
+            "io.kubewarden.policy.description",
+            "io.kubewarden.policy.author",
+            "io.kubewarden.policy.url",
+            "io.kubewarden.policy.source",
+            "io.kubewarden.policy.license",
+        ];
+        let mut annotations = metadata.annotations.clone().unwrap_or_default();
+
+        let mut table = Table::new();
+        table.set_format(FormatBuilder::new().padding(0, 1).build());
+
+        table.add_row(row![Fmbl -> "Details"]);
+        for annotation in pretty_annotations.iter() {
+            if let Some(value) = annotations.get(&String::from(*annotation)) {
+                table.add_row(row![Fgbl -> self.annotation_to_row_key(annotation), d -> value]);
+                annotations.remove(&String::from(*annotation));
+            }
+        }
+        table.add_row(row![Fgbl -> "mutating:", metadata.mutating]);
+        table.add_row(row![Fgbl -> "protocol version:", protocol_version]);
+
+        let _usage = annotations.remove("io.kubewarden.policy.usage");
+        if !annotations.is_empty() {
+            table.add_row(row![]);
+            table.add_row(row![Fmbl -> "Annotations"]);
+            for (annotation, value) in annotations.iter() {
+                table.add_row(row![Fgbl -> annotation, d -> value]);
+            }
+        }
+
+        let labels = metadata.labels.clone().unwrap_or_default();
+        if !labels.is_empty() {
+            table.add_row(row![]);
+            table.add_row(row![Fmbl -> "Labels"]);
+            for (label, value) in labels.iter() {
+                table.add_row(row![Fgbl -> label, d -> value]);
+            }
+        }
+        table.printstd();
+
+        Ok(())
+    }
+
+    fn print_metadata_rules(&self, metadata: &Metadata) -> Result<()> {
+        let rules_yaml = serde_yaml::to_string(&metadata.rules)?;
+
+        // Quick hack to print a colorized "Rules" section, with the same
+        // style as the other sections we print
+        let mut table = Table::new();
+        table.set_format(FormatBuilder::new().padding(0, 1).build());
+        table.add_row(row![Fmbl -> "Rules"]);
+        table.printstd();
+
+        let text = format!("```yaml\n{}```", rules_yaml);
+        self.render_markdown(&text)
+    }
+
+    fn print_metadata_usage(&self, metadata: &Metadata) -> Result<()> {
+        let usage = match metadata.annotations.clone() {
+            None => None,
+            Some(annotations) => match annotations.get("io.kubewarden.policy.usage") {
+                Some(usage) => Some(String::from(usage)),
+                None => None,
+            },
+        };
+
+        if usage.is_none() {
+            return Ok(());
+        }
+
+        // Quick hack to print a colorized "Rules" section, with the same
+        // style as the other sections we print
+        let mut table = Table::new();
+        table.set_format(FormatBuilder::new().padding(0, 1).build());
+        table.add_row(row![Fmbl -> "Usage"]);
+        table.printstd();
+
+        self.render_markdown(&usage.unwrap())
+    }
+
+    fn render_markdown(&self, text: &str) -> Result<()> {
+        let size = TerminalSize::detect().unwrap_or_default();
+        let columns = size.columns;
+        let settings = mdcat::Settings {
+            terminal_capabilities: TerminalCapabilities::detect(),
+            terminal_size: TerminalSize { columns, ..size },
+            resource_access: ResourceAccess::LocalOnly,
+            syntax_set: SyntaxSet::load_defaults_newlines(),
+        };
+        let parser = Parser::new_ext(
+            text,
+            Options::ENABLE_TASKLISTS | Options::ENABLE_STRIKETHROUGH,
+        );
+        let env = mdcat::Environment::for_local_directory(&std::env::current_dir()?)?;
+
+        let stdout = std::io::stdout();
+        let mut output = stdout.lock();
+        mdcat::push_tty(&settings, &env, &mut output, parser).or_else(|error| {
+            if error.kind() == std::io::ErrorKind::BrokenPipe {
+                Ok(())
+            } else {
+                Err(anyhow!("Cannot render markdown to stdout: {:?}", error))
+            }
+        })
+    }
+}
+
+impl MetadataPrinter for MetadataPrettyPrinter {
+    fn print(&self, metadata: &Metadata) -> Result<()> {
+        self.print_metadata_generic_info(metadata)?;
+        println!();
+        self.print_metadata_rules(metadata)?;
+        println!();
+        self.print_metadata_usage(metadata)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,7 @@ async fn main() -> Result<()> {
             (@subcommand inspect =>
              (about: "Inspect Kubewarden policy")
              (@arg ("uri"): * "Policy URI. Supported schemes: registry://, https://, file://")
+             (@arg ("output"): -o --("output") +takes_value "output format. One of: yaml")
             )
             (@subcommand manifest =>
              (about: "Scaffold a Kubernetes resource")
@@ -186,7 +187,7 @@ async fn main() -> Result<()> {
         Some("inspect") => {
             if let Some(ref matches) = matches.subcommand_matches("inspect") {
                 let uri = matches.value_of("uri").unwrap();
-                inspect::inspect(uri)?;
+                inspect::inspect(uri, matches.value_of("output"))?;
             };
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use clap::{
     clap_app, crate_authors, crate_description, crate_name, crate_version, AppSettings, ArgMatches,
 };
 use std::{
+    convert::TryFrom,
     fs,
     path::{Path, PathBuf},
     str::FromStr,
@@ -187,7 +188,9 @@ async fn main() -> Result<()> {
         Some("inspect") => {
             if let Some(ref matches) = matches.subcommand_matches("inspect") {
                 let uri = matches.value_of("uri").unwrap();
-                inspect::inspect(uri, matches.value_of("output"))?;
+                let output = inspect::OutputType::try_from(matches.value_of("output"))?;
+
+                inspect::inspect(uri, output)?;
             };
             Ok(())
         }


### PR DESCRIPTION
The `kwctl inspect` command now produces colorized and formatted output.

It's still possible to produce simple YAML outpout by using the `-o yaml` flag.

**Note well:** this branch depends on a currently unreleased version of the `policy-evaluator` crate, see https://github.com/kubewarden/policy-evaluator/pull/7

## Input metadata

The next examples take a policy that was annotated using this metadata:

```yaml
rules:
- apiGroups: [""]
  apiVersions: ["v1"]
  resources: ["pods"]
  operations: ["CREATE", "UPDATE"]
mutating: false
labels:
  production: false
annotations:
  name.castelli.hello: world
  io.kubewarden.policy.title: psp-apparmor
  io.kubewarden.policy.description: Replacement for the Kubernetes Pod Security Policy that controls the usage of AppArmor profiles
  io.kubewarden.policy.author: Flavio Castelli
  io.kubewarden.policy.url: https://github.com/kubewarden/psp-apparmor
  io.kubewarden.policy.source: https://github.com/kubewarden/psp-apparmor
  io.kubewarden.policy.license: Apache-2.0
  io.kubewarden.policy.usage: |
    This policy works by defining a whitelist of allowed AppArmor profiles. Pods are then inspected at creation and update time, to ensure only approved profiles are used.

    When no AppArmor profile is defined, Kubernetes will leave the final choice to the underlying container runtime. This will result in using the default AppArmor profile provided by Container Runtime. Because of that, the default behaviour of this policy is to accept workloads that do not have an AppArmor profile specified.

    The policy can be configured with the following data structure:
    ```yaml
    # list of allowed profiles
    allowed_profiles:
    - runtime/default
    - localhost/my-special-workload
    ```
```

## YAML output

The `kwctl inspect --output yaml ...` command produces the old yaml output:

![image](https://user-images.githubusercontent.com/22728/119826958-e3538300-bef8-11eb-9368-f43ecb42250c.png)

## New "pretty" output

By default this is the output produced by `kwctl inspect`:

![image](https://user-images.githubusercontent.com/22728/119827046-febe8e00-bef8-11eb-9cbd-627ca6f2b21c.png)
