### PR TITLE
Handle the annotatedBy field of policy metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.9.5",
  "syntect",
+ "tempfile",
  "tokio 1.6.0",
  "tokio-compat-02",
  "tracing",
@@ -2389,8 +2390,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.1.11"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.11#d521aad21ac79e8fe431d384772e225f27a0ddc6"
+version = "0.1.13"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.13#1a81978a76ae4b39c105f7fb0838a67a2947071b"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ directories = "3.0.2"
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
 kubewarden-policy-sdk = "0.2.2"
 mdcat = "0.22"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.11" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.13" }
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.9" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
@@ -36,3 +36,6 @@ tracing-subscriber = { version= "0.2", features = ["fmt"] }
 url = "2.2.0"
 validator = { version = "0.13", features = ["derive"] }
 walrus = "0.19.0"
+
+[dev-dependencies]
+tempfile = "3.2.0"

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use kubewarden_policy_sdk::metadata::ProtocolVersion;
 use policy_evaluator::{
     constants::KUBEWARDEN_CUSTOM_SECTION_METADATA, policy_evaluator::PolicyEvaluator,
     policy_metadata::Metadata,
@@ -14,20 +15,35 @@ pub(crate) fn write_annotation(
     metadata_path: PathBuf,
     destination: PathBuf,
 ) -> Result<()> {
-    let metadata = prepare_metadata(wasm_path.clone(), metadata_path)?;
+    let metadata = prepare_metadata(wasm_path.clone(), metadata_path, protocol_detector)?;
     write_annotated_wasm_file(wasm_path, destination, metadata)
 }
 
-fn prepare_metadata(wasm_path: PathBuf, metadata_path: PathBuf) -> Result<Metadata> {
+fn protocol_detector(wasm_path: PathBuf) -> Result<ProtocolVersion> {
+    let policy_evaluator = PolicyEvaluator::new(wasm_path.as_path(), None)?;
+    policy_evaluator
+        .protocol_version()
+        .map_err(|e| anyhow!("Cannot compute ProtocolVersion used by the policy: {:?}", e))
+}
+
+fn prepare_metadata(
+    wasm_path: PathBuf,
+    metadata_path: PathBuf,
+    detect_protocol_func: impl Fn(PathBuf) -> Result<ProtocolVersion>,
+) -> Result<Metadata> {
     let metadata_file = File::open(metadata_path)?;
     let mut metadata: Metadata = serde_yaml::from_reader(&metadata_file)?;
 
-    let policy_evaluator = PolicyEvaluator::new(wasm_path.as_path(), None)?;
-    let protocol_version = policy_evaluator
-        .protocol_version()
-        .map_err(|e| anyhow!("Cannot compute ProtocolVersion used by the policy: {:?}", e))?;
+    let protocol_version = detect_protocol_func(wasm_path)?;
 
     metadata.protocol_version = Some(protocol_version);
+
+    let mut annotations = metadata.annotations.unwrap_or_default();
+    annotations.insert(
+        String::from(constants::ANNOTATION_KWCTL_VERSION),
+        String::from(env!("CARGO_PKG_VERSION")),
+    );
+    metadata.annotations = Some(annotations);
 
     metadata
         .validate()
@@ -53,4 +69,140 @@ fn write_annotated_wasm_file(
 
     module.emit_wasm_file(output_path)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn mock_protocol_version_detector_v1(_wasm_path: PathBuf) -> Result<ProtocolVersion> {
+        Ok(ProtocolVersion::V1)
+    }
+
+    #[test]
+    fn test_kwctl_version_is_added_to_already_populated_annotations() -> Result<()> {
+        let dir = tempdir()?;
+
+        let file_path = dir.path().join("metadata.yml");
+        let mut file = File::create(file_path.clone())?;
+
+        let expected_policy_title = "psp-test";
+        let raw_metadata = format!(
+            r#"
+        rules:
+        - apiGroups: [""]
+          apiVersions: ["v1"]
+          resources: ["pods"]
+          operations: ["CREATE", "UPDATE"]
+        mutating: false
+        annotations:
+          io.kubewarden.policy.title: {}
+        "#,
+            expected_policy_title
+        );
+
+        write!(file, "{}", raw_metadata)?;
+
+        let metadata = prepare_metadata(
+            PathBuf::from("irrelevant.wasm"),
+            file_path,
+            mock_protocol_version_detector_v1,
+        )?;
+        let annotations = metadata.annotations.unwrap();
+
+        assert_eq!(
+            annotations.get(crate::constants::ANNOTATION_POLICY_TITLE),
+            Some(&String::from(expected_policy_title))
+        );
+
+        assert_eq!(
+            annotations.get(crate::constants::ANNOTATION_KWCTL_VERSION),
+            Some(&String::from(env!("CARGO_PKG_VERSION"))),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_kwctl_version_is_overwrote_when_user_accidentally_provides_it() -> Result<()> {
+        let dir = tempdir()?;
+
+        let file_path = dir.path().join("metadata.yml");
+        let mut file = File::create(file_path.clone())?;
+
+        let expected_policy_title = "psp-test";
+        let raw_metadata = format!(
+            r#"
+        rules:
+        - apiGroups: [""]
+          apiVersions: ["v1"]
+          resources: ["pods"]
+          operations: ["CREATE", "UPDATE"]
+        mutating: false
+        annotations:
+          io.kubewarden.policy.title: {}
+          {}: NOT_VALID
+        "#,
+            expected_policy_title,
+            crate::constants::ANNOTATION_KWCTL_VERSION,
+        );
+
+        write!(file, "{}", raw_metadata)?;
+
+        let metadata = prepare_metadata(
+            PathBuf::from("irrelevant.wasm"),
+            file_path,
+            mock_protocol_version_detector_v1,
+        )?;
+        let annotations = metadata.annotations.unwrap();
+
+        assert_eq!(
+            annotations.get(crate::constants::ANNOTATION_POLICY_TITLE),
+            Some(&String::from(expected_policy_title))
+        );
+
+        assert_eq!(
+            annotations.get(crate::constants::ANNOTATION_KWCTL_VERSION),
+            Some(&String::from(env!("CARGO_PKG_VERSION"))),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_kwctl_version_is_added_when_annotations_is_none() -> Result<()> {
+        let dir = tempdir()?;
+
+        let file_path = dir.path().join("metadata.yml");
+        let mut file = File::create(file_path.clone())?;
+
+        let raw_metadata = format!(
+            r#"
+        rules:
+        - apiGroups: [""]
+          apiVersions: ["v1"]
+          resources: ["pods"]
+          operations: ["CREATE", "UPDATE"]
+        mutating: false
+        "#
+        );
+
+        write!(file, "{}", raw_metadata)?;
+
+        let metadata = prepare_metadata(
+            PathBuf::from("irrelevant.wasm"),
+            file_path,
+            mock_protocol_version_detector_v1,
+        )?;
+        let annotations = metadata.annotations.unwrap();
+
+        assert_eq!(
+            annotations.get(crate::constants::ANNOTATION_KWCTL_VERSION),
+            Some(&String::from(env!("CARGO_PKG_VERSION"))),
+        );
+
+        Ok(())
+    }
 }

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,12 +1,13 @@
 use anyhow::{anyhow, Result};
-use std::fs::File;
-use std::path::PathBuf;
-use validator::Validate;
-
 use policy_evaluator::{
     constants::KUBEWARDEN_CUSTOM_SECTION_METADATA, policy_evaluator::PolicyEvaluator,
     policy_metadata::Metadata,
 };
+use std::fs::File;
+use std::path::PathBuf;
+use validator::Validate;
+
+use crate::constants;
 
 pub(crate) fn write_annotation(
     wasm_path: PathBuf,

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use std::path::PathBuf;
 use validator::Validate;
 
-use crate::constants;
+use crate::constants::*;
 
 pub(crate) fn write_annotation(
     wasm_path: PathBuf,
@@ -40,7 +40,7 @@ fn prepare_metadata(
 
     let mut annotations = metadata.annotations.unwrap_or_default();
     annotations.insert(
-        String::from(constants::ANNOTATION_KWCTL_VERSION),
+        String::from(ANNOTATION_KWCTL_VERSION),
         String::from(env!("CARGO_PKG_VERSION")),
     );
     metadata.annotations = Some(annotations);
@@ -113,12 +113,12 @@ mod tests {
         let annotations = metadata.annotations.unwrap();
 
         assert_eq!(
-            annotations.get(crate::constants::ANNOTATION_POLICY_TITLE),
+            annotations.get(ANNOTATION_POLICY_TITLE),
             Some(&String::from(expected_policy_title))
         );
 
         assert_eq!(
-            annotations.get(crate::constants::ANNOTATION_KWCTL_VERSION),
+            annotations.get(ANNOTATION_KWCTL_VERSION),
             Some(&String::from(env!("CARGO_PKG_VERSION"))),
         );
 
@@ -145,8 +145,7 @@ mod tests {
           io.kubewarden.policy.title: {}
           {}: NOT_VALID
         "#,
-            expected_policy_title,
-            crate::constants::ANNOTATION_KWCTL_VERSION,
+            expected_policy_title, ANNOTATION_KWCTL_VERSION,
         );
 
         write!(file, "{}", raw_metadata)?;
@@ -159,12 +158,12 @@ mod tests {
         let annotations = metadata.annotations.unwrap();
 
         assert_eq!(
-            annotations.get(crate::constants::ANNOTATION_POLICY_TITLE),
+            annotations.get(ANNOTATION_POLICY_TITLE),
             Some(&String::from(expected_policy_title))
         );
 
         assert_eq!(
-            annotations.get(crate::constants::ANNOTATION_KWCTL_VERSION),
+            annotations.get(ANNOTATION_KWCTL_VERSION),
             Some(&String::from(env!("CARGO_PKG_VERSION"))),
         );
 
@@ -199,7 +198,7 @@ mod tests {
         let annotations = metadata.annotations.unwrap();
 
         assert_eq!(
-            annotations.get(crate::constants::ANNOTATION_KWCTL_VERSION),
+            annotations.get(ANNOTATION_KWCTL_VERSION),
             Some(&String::from(env!("CARGO_PKG_VERSION"))),
         );
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,3 +5,5 @@ pub(crate) const ANNOTATION_POLICY_URL: &str = "io.kubewarden.policy.url";
 pub(crate) const ANNOTATION_POLICY_SOURCE: &str = "io.kubewarden.policy.source";
 pub(crate) const ANNOTATION_POLICY_LICENSE: &str = "io.kubewarden.policy.license";
 pub(crate) const ANNOTATION_POLICY_USAGE: &str = "io.kubewarden.policy.usage";
+
+pub(crate) const ANNOTATION_KWCTL_VERSION: &str = "io.kubewarden.kwctl";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,7 @@
+pub(crate) const ANNOTATION_POLICY_TITLE: &str = "io.kubewarden.policy.title";
+pub(crate) const ANNOTATION_POLICY_DESCRIPTION: &str = "io.kubewarden.policy.description";
+pub(crate) const ANNOTATION_POLICY_AUTHOR: &str = "io.kubewarden.policy.author";
+pub(crate) const ANNOTATION_POLICY_URL: &str = "io.kubewarden.policy.url";
+pub(crate) const ANNOTATION_POLICY_SOURCE: &str = "io.kubewarden.policy.source";
+pub(crate) const ANNOTATION_POLICY_LICENSE: &str = "io.kubewarden.policy.license";
+pub(crate) const ANNOTATION_POLICY_USAGE: &str = "io.kubewarden.policy.usage";

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -78,12 +78,12 @@ impl MetadataPrettyPrinter {
         }
 
         let pretty_annotations = vec![
-            "io.kubewarden.policy.title",
-            "io.kubewarden.policy.description",
-            "io.kubewarden.policy.author",
-            "io.kubewarden.policy.url",
-            "io.kubewarden.policy.source",
-            "io.kubewarden.policy.license",
+            crate::constants::ANNOTATION_POLICY_TITLE,
+            crate::constants::ANNOTATION_POLICY_DESCRIPTION,
+            crate::constants::ANNOTATION_POLICY_AUTHOR,
+            crate::constants::ANNOTATION_POLICY_URL,
+            crate::constants::ANNOTATION_POLICY_SOURCE,
+            crate::constants::ANNOTATION_POLICY_LICENSE,
         ];
         let mut annotations = metadata.annotations.clone().unwrap_or_default();
 
@@ -100,7 +100,7 @@ impl MetadataPrettyPrinter {
         table.add_row(row![Fgbl -> "mutating:", metadata.mutating]);
         table.add_row(row![Fgbl -> "protocol version:", protocol_version]);
 
-        let _usage = annotations.remove("io.kubewarden.policy.usage");
+        let _usage = annotations.remove(crate::constants::ANNOTATION_POLICY_USAGE);
         if !annotations.is_empty() {
             table.add_row(row![]);
             table.add_row(row![Fmbl -> "Annotations"]);
@@ -131,7 +131,7 @@ impl MetadataPrettyPrinter {
         let usage = match metadata.annotations.clone() {
             None => None,
             Some(annotations) => annotations
-                .get("io.kubewarden.policy.usage")
+                .get(crate::constants::ANNOTATION_POLICY_USAGE)
                 .map(String::from),
         };
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -7,6 +7,8 @@ use pulldown_cmark::{Options, Parser};
 use std::convert::TryFrom;
 use syntect::parsing::SyntaxSet;
 
+use crate::constants::*;
+
 pub(crate) fn inspect(uri: &str, output: OutputType) -> Result<()> {
     let uri = crate::utils::map_path_to_uri(uri)?;
     let wasm_path = crate::utils::wasm_path(uri.as_str())?;
@@ -78,12 +80,12 @@ impl MetadataPrettyPrinter {
         }
 
         let pretty_annotations = vec![
-            crate::constants::ANNOTATION_POLICY_TITLE,
-            crate::constants::ANNOTATION_POLICY_DESCRIPTION,
-            crate::constants::ANNOTATION_POLICY_AUTHOR,
-            crate::constants::ANNOTATION_POLICY_URL,
-            crate::constants::ANNOTATION_POLICY_SOURCE,
-            crate::constants::ANNOTATION_POLICY_LICENSE,
+            ANNOTATION_POLICY_TITLE,
+            ANNOTATION_POLICY_DESCRIPTION,
+            ANNOTATION_POLICY_AUTHOR,
+            ANNOTATION_POLICY_URL,
+            ANNOTATION_POLICY_SOURCE,
+            ANNOTATION_POLICY_LICENSE,
         ];
         let mut annotations = metadata.annotations.clone().unwrap_or_default();
 
@@ -100,7 +102,7 @@ impl MetadataPrettyPrinter {
         table.add_row(row![Fgbl -> "mutating:", metadata.mutating]);
         table.add_row(row![Fgbl -> "protocol version:", protocol_version]);
 
-        let _usage = annotations.remove(crate::constants::ANNOTATION_POLICY_USAGE);
+        let _usage = annotations.remove(ANNOTATION_POLICY_USAGE);
         if !annotations.is_empty() {
             table.add_row(row![]);
             table.add_row(row![Fmbl -> "Annotations"]);
@@ -130,9 +132,7 @@ impl MetadataPrettyPrinter {
     fn print_metadata_usage(&self, metadata: &Metadata) -> Result<()> {
         let usage = match metadata.annotations.clone() {
             None => None,
-            Some(annotations) => annotations
-                .get(crate::constants::ANNOTATION_POLICY_USAGE)
-                .map(String::from),
+            Some(annotations) => annotations.get(ANNOTATION_POLICY_USAGE).map(String::from),
         };
 
         if usage.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use policy_fetcher::store::DEFAULT_ROOT;
 use policy_fetcher::PullDestination;
 
 mod annotate;
+mod constants;
 mod inspect;
 mod manifest;
 mod policies;


### PR DESCRIPTION
Ensure kwctl writes its version when annotating a policy.

At the same time, ensure `inspect`ion of a policy shows who annotated it.