### PR TITLE
Policy testdrive missing features

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -47,6 +47,17 @@ pub(crate) async fn pull_and_run(
         _ => Err(anyhow!("request to evaluate is invalid")),
     }?;
 
+    // validate the settings given by the user
+    let settings_validation_response = policy_evaluator.validate_settings();
+    if !settings_validation_response.valid {
+        println!("{}", serde_json::to_string(&settings_validation_response)?);
+        return Err(anyhow!(
+            "Provided settings are not valid: {:?}",
+            settings_validation_response.message
+        ));
+    }
+
+    // evaluate request
     let response = policy_evaluator.validate(req_obj.clone());
     println!("{}", serde_json::to_string(&response)?);
 


### PR DESCRIPTION
This PR brings back two features that got lost during the `policy-testdrive` -> `kwctl` rewrite. They are both related with the behaviour of the `run` command:

1. Allow user to specify the policy settings on the cli, via the new `--settings-json` flag. This makes the process of writing bat tests easier
2. Ensure the settings provided by the user are actually validated. This must happen **before** the request is evaluated. Invalid settings lead `kwctl` to exit with an error