### PR TITLE
Handle execution mode inside of annote and inspect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 [[package]]
 name = "burrego"
 version = "0.1.1"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#27bb30c46b98fe749d0b2a535941f33a4a434018"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#be4aa31fe447695a93462a6f944653fb200fe97a"
 dependencies = [
  "anyhow",
  "clap",
@@ -1288,7 +1288,7 @@ dependencies = [
  "http 0.2.4",
  "indexmap",
  "slab",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-util",
  "tracing",
 ]
@@ -1389,7 +1389,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tower-service",
  "tracing",
  "want",
@@ -1403,7 +1403,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-io-timeout",
 ]
 
@@ -1416,7 +1416,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-native-tls",
 ]
 
@@ -1648,7 +1648,7 @@ dependencies = [
  "serde_yaml",
  "static_assertions",
  "thiserror",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-native-tls",
  "tokio-util",
  "tower",
@@ -1704,7 +1704,7 @@ dependencies = [
  "sha2",
  "syntect",
  "tempfile",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-compat-02",
  "tracing",
  "tracing-futures",
@@ -1712,6 +1712,7 @@ dependencies = [
  "url 2.2.2",
  "validator",
  "walrus",
+ "wasmparser 0.80.0",
 ]
 
 [[package]]
@@ -1798,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-owned"
@@ -2069,7 +2070,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tracing",
  "www-authenticate",
 ]
@@ -2292,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "policy-evaluator"
 version = "0.1.19"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#27bb30c46b98fe749d0b2a535941f33a4a434018"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#be4aa31fe447695a93462a6f944653fb200fe97a"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -2659,7 +2660,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-native-tls",
  "url 2.2.2",
  "wasm-bindgen",
@@ -3224,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -3252,7 +3253,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.7",
  "tokio 0.2.25",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-stream",
 ]
 
@@ -3263,7 +3264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -3284,7 +3285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -3295,7 +3296,7 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -3309,7 +3310,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -3330,7 +3331,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-util",
  "tower-layer",
  "tower-service",
@@ -3482,12 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -3852,6 +3850,12 @@ name = "wasmparser"
 version = "0.78.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+
+[[package]]
+name = "wasmparser"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f71b80b8193e50910919e7d1bc956d2b4f42b1cb1fad84bacb59332c16f2cf"
 
 [[package]]
 name = "wasmtime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version= "0.2", features = ["fmt"] }
 url = "2.2.0"
 validator = { version = "0.13", features = ["derive"] }
 walrus = "0.19.0"
+wasmparser = "0.80.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,10 +1,7 @@
+use crate::backend::{Backend, BackendDetector};
 use anyhow::{anyhow, Result};
 use kubewarden_policy_sdk::metadata::ProtocolVersion;
-use policy_evaluator::{
-    constants::*,
-    policy_evaluator::{PolicyEvaluator, PolicyExecutionMode},
-    policy_metadata::Metadata,
-};
+use policy_evaluator::{constants::*, policy_metadata::Metadata};
 use std::fs::File;
 use std::path::PathBuf;
 use validator::Validate;
@@ -14,33 +11,30 @@ pub(crate) fn write_annotation(
     metadata_path: PathBuf,
     destination: PathBuf,
 ) -> Result<()> {
-    let metadata = prepare_metadata(wasm_path.clone(), metadata_path, protocol_detector)?;
+    let backend_detector = BackendDetector::default();
+    let metadata = prepare_metadata(wasm_path.clone(), metadata_path, backend_detector)?;
     write_annotated_wasm_file(wasm_path, destination, metadata)
-}
-
-fn protocol_detector(wasm_path: PathBuf) -> Result<ProtocolVersion> {
-    let mut policy_evaluator = PolicyEvaluator::from_file(
-        String::from(wasm_path.to_string_lossy()),
-        wasm_path.as_path(),
-        PolicyExecutionMode::KubewardenWapc,
-        None,
-    )?;
-    policy_evaluator
-        .protocol_version()
-        .map_err(|e| anyhow!("Cannot compute ProtocolVersion used by the policy: {:?}", e))
 }
 
 fn prepare_metadata(
     wasm_path: PathBuf,
     metadata_path: PathBuf,
-    detect_protocol_func: impl Fn(PathBuf) -> Result<ProtocolVersion>,
+    backend_detector: BackendDetector,
 ) -> Result<Metadata> {
-    let metadata_file = File::open(metadata_path)?;
-    let mut metadata: Metadata = serde_yaml::from_reader(&metadata_file)?;
+    let metadata_file =
+        File::open(metadata_path).map_err(|e| anyhow!("Error opening metadata file: {}", e))?;
+    let mut metadata: Metadata = serde_yaml::from_reader(&metadata_file)
+        .map_err(|e| anyhow!("Error unmarshalling metadata {}", e))?;
 
-    let protocol_version = detect_protocol_func(wasm_path)?;
+    let backend = backend_detector.detect(wasm_path, &metadata)?;
 
-    metadata.protocol_version = Some(protocol_version);
+    match backend {
+        Backend::Opa => metadata.protocol_version = Some(ProtocolVersion::Unknown),
+        Backend::OpaGatekeeper => metadata.protocol_version = Some(ProtocolVersion::Unknown),
+        Backend::KubewardenWapc(protocol_version) => {
+            metadata.protocol_version = Some(protocol_version)
+        }
+    };
 
     let mut annotations = metadata.annotations.unwrap_or_default();
     annotations.insert(
@@ -85,6 +79,14 @@ mod tests {
         Ok(ProtocolVersion::V1)
     }
 
+    fn mock_rego_policy_detector_true(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn mock_rego_policy_detector_false(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(false)
+    }
+
     #[test]
     fn test_kwctl_version_is_added_to_already_populated_annotations() -> Result<()> {
         let dir = tempdir()?;
@@ -109,10 +111,14 @@ mod tests {
 
         write!(file, "{}", raw_metadata)?;
 
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_false,
+            mock_protocol_version_detector_v1,
+        );
         let metadata = prepare_metadata(
             PathBuf::from("irrelevant.wasm"),
             file_path,
-            mock_protocol_version_detector_v1,
+            backend_detector,
         )?;
         let annotations = metadata.annotations.unwrap();
 
@@ -154,10 +160,14 @@ mod tests {
 
         write!(file, "{}", raw_metadata)?;
 
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_false,
+            mock_protocol_version_detector_v1,
+        );
         let metadata = prepare_metadata(
             PathBuf::from("irrelevant.wasm"),
             file_path,
-            mock_protocol_version_detector_v1,
+            backend_detector,
         )?;
         let annotations = metadata.annotations.unwrap();
 
@@ -189,21 +199,65 @@ mod tests {
           resources: ["pods"]
           operations: ["CREATE", "UPDATE"]
         mutating: false
+        executionMode: kubewarden-wapc
         "#
         );
 
         write!(file, "{}", raw_metadata)?;
 
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_false,
+            mock_protocol_version_detector_v1,
+        );
         let metadata = prepare_metadata(
             PathBuf::from("irrelevant.wasm"),
             file_path,
-            mock_protocol_version_detector_v1,
+            backend_detector,
         )?;
         let annotations = metadata.annotations.unwrap();
 
         assert_eq!(
             annotations.get(KUBEWARDEN_ANNOTATION_KWCTL_VERSION),
             Some(&String::from(env!("CARGO_PKG_VERSION"))),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_final_metadata_for_a_rego_policy() -> Result<()> {
+        let dir = tempdir()?;
+
+        let file_path = dir.path().join("metadata.yml");
+        let mut file = File::create(file_path.clone())?;
+
+        let raw_metadata = String::from(
+            r#"
+        rules:
+        - apiGroups: [""]
+          apiVersions: ["v1"]
+          resources: ["pods"]
+          operations: ["CREATE", "UPDATE"]
+        mutating: false
+        executionMode: opa
+        "#,
+        );
+
+        write!(file, "{}", raw_metadata)?;
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_true,
+            mock_protocol_version_detector_v1,
+        );
+        let metadata = prepare_metadata(
+            PathBuf::from("irrelevant.wasm"),
+            file_path,
+            backend_detector,
+        );
+        assert!(metadata.is_ok());
+        assert_eq!(
+            metadata.unwrap().protocol_version,
+            Some(ProtocolVersion::Unknown)
         );
 
         Ok(())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,168 @@
+use anyhow::{anyhow, Result};
+use kubewarden_policy_sdk::metadata::ProtocolVersion;
+use policy_evaluator::{
+    policy_evaluator::{PolicyEvaluator, PolicyExecutionMode},
+    policy_metadata::Metadata,
+};
+use std::path::PathBuf;
+
+pub(crate) enum Backend {
+    Opa,
+    OpaGatekeeper,
+    KubewardenWapc(ProtocolVersion),
+}
+
+type KubewardenProtocolDetectorFn = fn(PathBuf) -> Result<ProtocolVersion>;
+type RegoDetectorFn = fn(PathBuf) -> Result<bool>;
+
+// Looks at the Wasm module pointed by `wasm_path` and return whether it was generaed by a Rego
+// policy
+//
+// The code looks at the export symbols offered by the Wasm module.
+// Having at least one symbol that starts with the `opa_` prefix leads
+// the policy to be considered a Rego-based one.
+fn rego_policy_detector(wasm_path: PathBuf) -> Result<bool> {
+    let data: Vec<u8> = std::fs::read(wasm_path)?;
+    for payload in wasmparser::Parser::new(0).parse_all(&data) {
+        if let wasmparser::Payload::ExportSection(s) = payload? {
+            for export in s {
+                if export?.field.starts_with("opa_") {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+fn kubewarden_protocol_detector(wasm_path: PathBuf) -> Result<ProtocolVersion> {
+    let mut policy_evaluator = PolicyEvaluator::from_file(
+        String::from(wasm_path.to_string_lossy()),
+        wasm_path.as_path(),
+        PolicyExecutionMode::KubewardenWapc,
+        None,
+    )?;
+    policy_evaluator
+        .protocol_version()
+        .map_err(|e| anyhow!("Cannot compute ProtocolVersion used by the policy: {:?}", e))
+}
+
+pub(crate) struct BackendDetector {
+    kubewarden_protocol_detector_func: KubewardenProtocolDetectorFn,
+    rego_detector_func: RegoDetectorFn,
+}
+
+impl Default for BackendDetector {
+    fn default() -> Self {
+        BackendDetector {
+            kubewarden_protocol_detector_func: kubewarden_protocol_detector,
+            rego_detector_func: rego_policy_detector,
+        }
+    }
+}
+
+impl BackendDetector {
+    #[allow(dead_code)]
+    /// This method is intended to be used by unit tests
+    pub(crate) fn new(
+        rego_detector_func: RegoDetectorFn,
+        kubewarden_protocol_detector_func: KubewardenProtocolDetectorFn,
+    ) -> Self {
+        BackendDetector {
+            kubewarden_protocol_detector_func,
+            rego_detector_func,
+        }
+    }
+
+    pub(crate) fn detect(&self, wasm_path: PathBuf, metadata: &Metadata) -> Result<Backend> {
+        let is_rego_policy = (self.rego_detector_func)(wasm_path.clone()).map_err(|e| {
+            anyhow!(
+                "Error while checking if the policy has been created using Opa/Gatekeeper: {}",
+                e
+            )
+        })?;
+        match metadata.execution_mode {
+            PolicyExecutionMode::Opa => {
+                if is_rego_policy {
+                    Ok(Backend::Opa)
+                } else {
+                    Err(anyhow!(
+                        "Wrong value inside of policy's metatada for 'executionMode'. The policy has not been created using Rego"
+                    ))
+                }
+            }
+            PolicyExecutionMode::OpaGatekeeper => {
+                if is_rego_policy {
+                    Ok(Backend::OpaGatekeeper)
+                } else {
+                    Err(anyhow!(
+                        "Wrong value inside of policy's metatada for 'executionMode'. The policy has not been created using Rego"
+                    ))
+                }
+            }
+            PolicyExecutionMode::KubewardenWapc => {
+                if is_rego_policy {
+                    Err(anyhow!(
+                        "Wrong value inside of policy's metatada for 'executionMode'. This policy has been created using Rego"
+                    ))
+                } else {
+                    let protocol_version = (self.kubewarden_protocol_detector_func)(wasm_path)
+                        .map_err(|e| {
+                            anyhow!("Error while detecting Kubewarden protocol version: {:?}", e)
+                        })?;
+                    Ok(Backend::KubewardenWapc(protocol_version))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_protocol_version_detector_v1(_wasm_path: PathBuf) -> Result<ProtocolVersion> {
+        Ok(ProtocolVersion::V1)
+    }
+
+    fn mock_rego_policy_detector_true(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn mock_rego_policy_detector_false(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(false)
+    }
+
+    #[test]
+    fn test_execution_mode_cannot_be_kubewarden_for_a_rego_policy() {
+        let metadata = Metadata {
+            execution_mode: PolicyExecutionMode::KubewardenWapc,
+            ..Default::default()
+        };
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_true,
+            mock_protocol_version_detector_v1,
+        );
+        let backend = backend_detector.detect(PathBuf::from("irrelevant.wasm"), &metadata);
+        assert!(backend.is_err());
+    }
+
+    #[test]
+    fn test_execution_mode_cannot_be_opa_or_gatekeeper_for_a_kubewarden_policy() {
+        for execution_mode in vec![PolicyExecutionMode::Opa, PolicyExecutionMode::OpaGatekeeper] {
+            let metadata = Metadata {
+                execution_mode,
+                ..Default::default()
+            };
+
+            let backend_detector = BackendDetector::new(
+                mock_rego_policy_detector_false,
+                mock_protocol_version_detector_v1,
+            );
+            let backend = backend_detector.detect(PathBuf::from("irrelevant.wasm"), &metadata);
+            assert!(backend.is_err());
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ use policy_fetcher::store::DEFAULT_ROOT;
 use policy_fetcher::PullDestination;
 
 mod annotate;
+mod backend;
 mod cli;
 mod completions;
 mod inspect;


### PR DESCRIPTION
Update the `annotate` and `inspect` commands to handle the new `executionMode` metadata attribute.

This fixes https://github.com/kubewarden/kwctl/issues/57