### PR TITLE
Do not push rego policies if they do not have metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use tracing::debug;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
-use policy_evaluator::{policy_evaluator::PolicyExecutionMode, policy_metadata::Metadata};
+use policy_evaluator::policy_evaluator::PolicyExecutionMode;
 use policy_fetcher::registry::config::{read_docker_config_json_file, DockerConfig};
 use policy_fetcher::sources::{read_sources_file, Sources};
 use policy_fetcher::store::DEFAULT_ROOT;
@@ -103,18 +103,9 @@ async fn main() -> Result<()> {
                     "policy push"
                 );
 
-                let policy = fs::read(&wasm_path)?;
                 let force = matches.is_present("force");
-                let metadata = Metadata::from_path(&wasm_path)?;
-                if metadata.is_none() {
-                    if force {
-                        eprintln!("Warning: pushing a non-annotated policy!");
-                    } else {
-                        return Err(anyhow!("Cannot push a policy that is not annotated. Use `annotate` command or `push --force`"));
-                    }
-                }
 
-                push::push(&policy, &uri, docker_config, sources).await?;
+                push::push(wasm_path, &uri, docker_config, sources, force).await?;
             };
             println!("Policy successfully pushed");
             Ok(())

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,14 +1,46 @@
-use anyhow::Result;
-
+use anyhow::{anyhow, Result};
+use policy_evaluator::policy_metadata::Metadata;
 use policy_fetcher::{registry::config::DockerConfig, registry::Registry, sources::Sources};
+use std::{fs, path::PathBuf};
+
+use crate::backend::BackendDetector;
 
 pub(crate) async fn push(
-    policy: &[u8],
+    wasm_path: PathBuf,
     uri: &str,
     docker_config: Option<DockerConfig>,
     sources: Option<Sources>,
+    force: bool,
 ) -> Result<()> {
+    match Metadata::from_path(&wasm_path)? {
+        Some(_) => {}
+        None => {
+            if force {
+                let backend_detector = BackendDetector::default();
+                if can_be_force_pushed_without_metadata(backend_detector, wasm_path.clone())? {
+                    eprintln!("Warning: pushing a non-annotated policy!");
+                } else {
+                    return Err(anyhow!("Rego policies cannot be pushed without metadata"));
+                }
+            } else {
+                return Err(anyhow!("Cannot push a policy that is not annotated. Use `annotate` command or `push --force`"));
+            }
+        }
+    };
+
+    let policy = fs::read(&wasm_path).map_err(|e| anyhow!("Cannot open policy file: {:?}", e))?;
     Registry::new(&docker_config)
-        .push(policy, uri, &sources)
+        .push(&policy, uri, &sources)
         .await
+}
+
+fn can_be_force_pushed_without_metadata(
+    backend_detector: BackendDetector,
+    wasm_path: PathBuf,
+) -> Result<bool> {
+    let is_rego = backend_detector
+        .is_rego_policy(&wasm_path)
+        .map_err(|e| anyhow!("Cannot understand if the policy is based on Rego: {:?}", e))?;
+
+    Ok(!is_rego)
 }


### PR DESCRIPTION
Refuse to push a rego policy that doesn't have metadata, even when the user gives the `--force` flag.

This is the last item on this list: https://github.com/kubewarden/kwctl/issues/55