### PR TITLE
Enable evaluation of Rego-based policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "blake2b_simd"
@@ -374,7 +374,7 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 [[package]]
 name = "burrego"
 version = "0.1.1"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#0240b3a10f380fc341784623aa49f7d7099c69a1"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#27bb30c46b98fe749d0b2a535941f33a4a434018"
 dependencies = [
  "anyhow",
  "clap",
@@ -1740,9 +1740,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "line-wrap"
@@ -1902,9 +1902,9 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "policy-evaluator"
 version = "0.1.19"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#0240b3a10f380fc341784623aa49f7d7099c69a1"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#27bb30c46b98fe749d0b2a535941f33a4a434018"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 [[package]]
 name = "burrego"
 version = "0.1.1"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#27bb30c46b98fe749d0b2a535941f33a4a434018"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#be4aa31fe447695a93462a6f944653fb200fe97a"
 dependencies = [
  "anyhow",
  "clap",
@@ -1288,7 +1288,7 @@ dependencies = [
  "http 0.2.4",
  "indexmap",
  "slab",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-util",
  "tracing",
 ]
@@ -1389,7 +1389,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tower-service",
  "tracing",
  "want",
@@ -1403,7 +1403,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-io-timeout",
 ]
 
@@ -1416,7 +1416,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-native-tls",
 ]
 
@@ -1648,7 +1648,7 @@ dependencies = [
  "serde_yaml",
  "static_assertions",
  "thiserror",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-native-tls",
  "tokio-util",
  "tower",
@@ -1704,7 +1704,7 @@ dependencies = [
  "sha2",
  "syntect",
  "tempfile",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-compat-02",
  "tracing",
  "tracing-futures",
@@ -1712,6 +1712,7 @@ dependencies = [
  "url 2.2.2",
  "validator",
  "walrus",
+ "wasmparser 0.80.0",
 ]
 
 [[package]]
@@ -1798,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-owned"
@@ -2069,7 +2070,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tracing",
  "www-authenticate",
 ]
@@ -2292,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "policy-evaluator"
 version = "0.1.19"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#27bb30c46b98fe749d0b2a535941f33a4a434018"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#be4aa31fe447695a93462a6f944653fb200fe97a"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -2659,7 +2660,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-native-tls",
  "url 2.2.2",
  "wasm-bindgen",
@@ -3224,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -3252,7 +3253,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.7",
  "tokio 0.2.25",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-stream",
 ]
 
@@ -3263,7 +3264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -3284,7 +3285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -3295,7 +3296,7 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -3309,7 +3310,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.10.0",
 ]
 
 [[package]]
@@ -3330,7 +3331,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "tokio 1.9.0",
+ "tokio 1.10.0",
  "tokio-util",
  "tower-layer",
  "tower-service",
@@ -3482,12 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -3852,6 +3850,12 @@ name = "wasmparser"
 version = "0.78.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+
+[[package]]
+name = "wasmparser"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f71b80b8193e50910919e7d1bc956d2b4f42b1cb1fad84bacb59332c16f2cf"
 
 [[package]]
 name = "wasmtime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,16 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
- "gimli",
+ "gimli 0.24.0",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+dependencies = [
+ "gimli 0.25.0",
 ]
 
 [[package]]
@@ -62,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "array_tool"
@@ -127,12 +136,11 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
+checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
 dependencies = [
  "concurrent-queue",
- "fastrand",
  "futures-lite",
  "libc",
  "log",
@@ -184,7 +192,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -219,9 +227,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -253,16 +261,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
- "addr2line",
+ "addr2line 0.16.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide 0.4.4",
- "object 0.25.3",
+ "object 0.26.0",
  "rustc-demangle",
 ]
 
@@ -364,10 +372,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
+name = "burrego"
+version = "0.1.1"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#0240b3a10f380fc341784623aa49f7d7099c69a1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "gtmpl",
+ "gtmpl_value",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+ "wasmtime",
+]
+
+[[package]]
 name = "bytemuck"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966d2ab714d0f785dbac0a0396251a35280aeb42413281617d0209ab4898435"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
 
 [[package]]
 name = "byteorder"
@@ -471,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 dependencies = [
  "jobserver",
 ]
@@ -558,43 +583,42 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44919ecaf6f99e8e737bc239408931c9a01e9a6c74814fee8242dd2506b65390"
+checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
 dependencies = [
  "cfg-if",
- "glob",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ca3560686e7c9c7ed7e0fe77469f2410ba5d7781b1acaa9adc8d8deea28e3e"
+checksum = "df3f8dd4f920a422c96c53fb6a91cc7932b865fdb60066ae9df7c329342d303f"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf9bf1ffffb6ce3d2e5ebc83549bd2436426c99b31cc550d521364cbe35d276"
+checksum = "ebe85f9a8dbf3c9dfa47ecb89828a7dc17c0b62015b84b5505fd4beba61c542c"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli",
+ "gimli 0.24.0",
  "log",
  "regalloc",
  "serde",
@@ -604,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc21936a5a6d07e23849ffe83e5c1f6f50305c074f4b2970ca50c13bf55b821"
+checksum = "12bc4be68da214a56bf9beea4212eb3b9eac16ca9f0b47762f907c4cd4684073"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -614,27 +638,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5b6ffaa87560bebe69a5446449da18090b126037920b0c1c6d5945f72faf6b"
+checksum = "a0c87b69923825cfbc3efde17d929a68cd5b50a4016b2bd0eb8c3933cc5bd8cd"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6b4a8bef04f82e4296782646f733c641d09497df2fabf791323fefaa44c64c"
+checksum = "fe683e7ec6e627facf44b2eab4b263507be4e7ef7ea06eb8cee5283d9b45370e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b783b351f966fce33e3c03498cb116d16d97a8f9978164a60920bd0d3a99c"
+checksum = "5da80025ca214f0118273f8b94c4790add3b776f0dc97afba6b711757497743b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -644,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c88d3dd48021ff1e37e978a00098524abd3513444ae252c08d37b310b3d2a"
+checksum = "e1c0e8c56f9a63f352a64aaa9c9eef7c205008b03593af7b128a3fbc46eae7e9"
 dependencies = [
  "cranelift-codegen",
  "target-lexicon",
@@ -654,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb6d408e2da77cdbbd65466298d44c86ae71c1785d2ab0d8657753cdb4d9d89"
+checksum = "d10ddafc5f1230d2190eb55018fcdecfcce728c9c2b975f2690ef13691d18eb5"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -690,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -920,9 +944,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fancy-regex"
-version = "0.3.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91abf6555234338687bb47913978d275539235fcb77ba9863b779090b42b14"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
 dependencies = [
  "bit-set",
  "regex",
@@ -930,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
+checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
 ]
@@ -1023,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1038,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1048,15 +1072,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1065,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-lite"
@@ -1080,15 +1104,15 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -1099,21 +1123,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -1123,7 +1147,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1209,10 +1233,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.0"
+name = "gimli"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "gloo-timers"
@@ -1225,6 +1249,29 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "gtmpl"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b924c0ea1149cd5cc9b208b33a4acb036ffb4b39c10048569de20616988a2b4"
+dependencies = [
+ "anyhow",
+ "gtmpl_value",
+ "lazy_static",
+ "percent-encoding 2.1.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gtmpl_value"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d61bf6605eabca491ef6db6ed194e0aa82900ccc8bdea4c56ac277102152dd5"
+dependencies = [
+ "anyhow",
+ "thiserror",
 ]
 
 [[package]]
@@ -1241,16 +1288,16 @@ dependencies = [
  "http 0.2.4",
  "indexmap",
  "slab",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -1263,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -1294,13 +1341,13 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes 1.0.1",
  "http 0.2.4",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
 ]
 
 [[package]]
@@ -1326,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.9"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -1340,9 +1387,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
  "socket2",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tower-service",
  "tracing",
  "want",
@@ -1355,8 +1402,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
- "pin-project-lite 0.2.6",
- "tokio 1.6.2",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
  "tokio-io-timeout",
 ]
 
@@ -1369,7 +1416,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tokio-native-tls",
 ]
 
@@ -1446,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1457,11 +1504,22 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609c23089c52d7edcf39d6cfd2cf581dcea7e059f80f1d91130887dceac77c1f"
+dependencies = [
+ "libc",
+ "rustc_version 0.4.0",
+ "winapi",
 ]
 
 [[package]]
@@ -1496,9 +1554,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+checksum = "f5ca711fd837261e14ec9e674f092cbb931d3fa1482b017ae59328ddc6f3212b"
 dependencies = [
  "libc",
 ]
@@ -1514,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1590,7 +1648,7 @@ dependencies = [
  "serde_yaml",
  "static_assertions",
  "thiserror",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tokio-native-tls",
  "tokio-util",
  "tower",
@@ -1599,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea0e3e0339064b89993411f766f0c5ce4a0df513310792eef7008934aceceb2"
+checksum = "61a46677c118ebeff46e1d3b09450715270366482a5b0cbeb8ef04152f7b4605"
 dependencies = [
  "anyhow",
  "k8s-openapi",
@@ -1610,6 +1668,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
+ "slog",
  "wapc-guest",
 ]
 
@@ -1645,7 +1704,7 @@ dependencies = [
  "sha2",
  "syntect",
  "tempfile",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tokio-compat-02",
  "tracing",
  "tracing-futures",
@@ -1681,9 +1740,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "line-wrap"
@@ -1978,19 +2037,20 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
 dependencies = [
  "crc32fast",
  "indexmap",
+ "memchr",
 ]
 
 [[package]]
 name = "object"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
+checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
 dependencies = [
  "memchr",
 ]
@@ -2009,7 +2069,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tracing",
  "www-authenticate",
 ]
@@ -2050,9 +2110,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2070,9 +2130,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg",
  "cc",
@@ -2083,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f100fcfb41e5385e0991f74981732049f9b896821542a219420491046baafdc2"
+checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
 dependencies = [
  "num-traits",
 ]
@@ -2116,7 +2176,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.8",
+ "redox_syscall 0.2.10",
  "smallvec",
  "winapi",
 ]
@@ -2161,18 +2221,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2187,9 +2247,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -2205,9 +2265,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plist"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679104537029ed2287c216bfb942bbf723f48ee98f0aef15611634173a74ef21"
+checksum = "a38d026d73eeaf2ade76309d0c65db5a35ecf649e3cec428db316243ea9d6711"
 dependencies = [
  "base64 0.13.0",
  "chrono",
@@ -2232,10 +2292,11 @@ dependencies = [
 [[package]]
 name = "policy-evaluator"
 version = "0.1.19"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.1.19#a56be60fd4ec479e14dfaba31a406cffe0095939"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#0240b3a10f380fc341784623aa49f7d7099c69a1"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
+ "burrego",
  "hyper",
  "json-patch",
  "k8s-openapi",
@@ -2369,18 +2430,18 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ff0279b4a85e576b97e4a21d13e437ebcd56612706cde5d3f0d5c9399490c0"
+checksum = "14ce37fa8c0428a37307d163292add09b3aedc003472e6b3622486878404191d"
 dependencies = [
  "cc",
 ]
@@ -2484,9 +2545,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2509,7 +2570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.3",
- "redox_syscall 0.2.8",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -2573,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.1",
@@ -2593,12 +2654,12 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
  "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tokio-native-tls",
  "url 2.2.2",
  "wasm-bindgen",
@@ -2636,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rustc-hash"
@@ -2661,7 +2722,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.3",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -2796,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "semver-parser"
@@ -2811,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -2830,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2841,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2890,9 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
@@ -2923,9 +2984,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+
+[[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "smallvec"
@@ -2935,9 +3002,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
@@ -2969,9 +3036,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2980,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfac2b23b4d049dc9a89353b4e06bbc85a8f42020cccbe5409a115cf19031e5"
+checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
 dependencies = [
  "bincode",
  "bitflags",
@@ -3020,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
+checksum = "b0652da4c4121005e9ed22b79f6c5f2d9e2752906b53a33e9490489ba421a6fb"
 
 [[package]]
 name = "tempfile"
@@ -3033,7 +3100,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand",
- "redox_syscall 0.2.8",
+ "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi",
 ]
@@ -3079,18 +3146,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3130,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3157,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea337f72e96efe29acc234d803a5981cd9a2b6ed21655cd7fc21cfe021e8ec7"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -3169,7 +3236,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
  "signal-hook-registry",
  "tokio-macros",
  "winapi",
@@ -3183,9 +3250,9 @@ checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
 dependencies = [
  "bytes 0.5.6",
  "once_cell",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
  "tokio 0.2.25",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tokio-stream",
 ]
 
@@ -3195,15 +3262,15 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
- "pin-project-lite 0.2.6",
- "tokio 1.6.2",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3217,18 +3284,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.6.2",
+ "tokio 1.9.0",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.6",
- "tokio 1.6.2",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -3241,8 +3308,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.6",
- "tokio 1.6.2",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -3263,7 +3330,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "tokio 1.6.2",
+ "tokio 1.9.0",
  "tokio-util",
  "tower-layer",
  "tower-service",
@@ -3290,7 +3357,7 @@ checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if",
  "log",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.7",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3348,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3433,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -3451,10 +3518,11 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unsafe-io"
-version = "0.6.9"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f372ce89b46cb10aace91021ff03f26cf97594f7515c0a8c1c2839c13814665d"
+checksum = "1598c579f79cdd11e677b3942b7bed5cb3369464cfd240f4c4a308ffaed6f5e4"
 dependencies = [
+ "io-lifetimes",
  "rustc_version 0.3.3",
  "winapi",
 ]
@@ -3556,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -3667,9 +3735,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452fc482d6c9cbd07451e62dfbae1dc381504028406fed3fed54e9dbcae820aa"
+checksum = "54ed414ed6ff3b95653ea07b237cf03c513015d94169aac159755e05a2eaa80f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3690,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a46e511a0783c3b416e6d643cd5f52d0a2749d7d5e6299728bfd4fc80fe3cf4"
+checksum = "6c67b1e49ae6d9bcab37a6f13594aed98d8ab8f5c2117b3bed543d8019688733"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3707,9 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if",
  "serde",
@@ -3719,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3734,9 +3802,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3746,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3756,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3769,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "wasmparser"
@@ -3787,9 +3855,9 @@ checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmtime"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b310b9d20fcf59385761d1ade7a3ef06aecc380e3d3172035b919eaf7465d9f7"
+checksum = "56828b11cd743a0e9b4207d1c7a8c1a66cb32d14601df10422072802a6aee86c"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3820,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14d500d5c3dc5f5c097158feee123d64b3097f0d836a2a27dff9c761c73c843"
+checksum = "99aca6335ad194d795342137a92afaec9338a2bfcf4caa4c667b5ece16c2bfa9"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -3841,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c525b39f062eada7db3c1298287b96dcb6e472b9f6b22501300b28d9fa7582f6"
+checksum = "519fa80abe29dc46fc43177cbe391e38c8613c59229c8d1d90d7f226c3c7cede"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -3856,14 +3924,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d2a763e7a6fc734218e0e463196762a4f409c483063d81e0e85f96343b2e0a"
+checksum = "6ddf6e9bca2f3bc1dd499db2a93d35c735176cff0de7daacdc18c3794f7082e0"
 dependencies = [
  "anyhow",
- "gimli",
+ "gimli 0.24.0",
  "more-asserts",
- "object 0.24.0",
+ "object 0.25.3",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.78.2",
@@ -3872,15 +3940,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64d0c2d881c31b0d65c1f2695e022d71eb60b9fbdd336aacca28208b58eac90"
+checksum = "0a991635b1cf1d1336fbea7a5f2c0e1dafaa54cb21c632d8414885278fa5d1b1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.24.0",
  "indexmap",
  "log",
  "more-asserts",
@@ -3891,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a089d44cd7e2465d41a53b840a5b4fca1bf6d1ecfebc970eac9592b34ea5f0b3"
+checksum = "7ab6bb95303636d1eba6f7fd2b67c1cd583f73303c73b1a3259b46bb1c2eb299"
 dependencies = [
  "cc",
  "libc",
@@ -3902,11 +3970,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4539ea734422b7c868107e2187d7746d8affbcaa71916d72639f53757ad707"
+checksum = "5f33a0ae79b7c8d050156b22e10fdc49dfb09cc482c251d12bf10e8a833498fb"
 dependencies = [
- "addr2line",
+ "addr2line 0.15.2",
  "anyhow",
  "cfg-if",
  "cranelift-codegen",
@@ -3914,10 +3982,10 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.24.0",
  "log",
  "more-asserts",
- "object 0.24.0",
+ "object 0.25.3",
  "rayon",
  "region",
  "serde",
@@ -3935,13 +4003,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1a8ff85246d091828e2225af521a6208ed28c997bb5c39eb697366dc2e2f2b"
+checksum = "4a879f03d416615f322dcb3aa5cb4cbc47b64b12be6aa235a64ab63a4281d50a"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object 0.24.0",
+ "object 0.25.3",
  "target-lexicon",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -3949,16 +4017,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24364d522dcd67c897c8fffc42e5bdfc57207bbb6d7eeade0da9d4a7d70105b"
+checksum = "171ae3107e8502667b16d336a1dd03e370aa6630a1ce26559aba572ade1031d1"
 dependencies = [
  "anyhow",
  "cfg-if",
- "gimli",
+ "gimli 0.24.0",
  "lazy_static",
  "libc",
- "object 0.24.0",
+ "object 0.25.3",
  "scroll",
  "serde",
  "target-lexicon",
@@ -3968,8 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-provider"
-version = "0.0.3"
-source = "git+https://github.com/flavio/wasmtime-provider.git?branch=update-wasmtime#fd0f75407ea0bccb58933f06ec150d139ed2ef08"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13c53c773951cd1eb77ff9358970acf3aadbb972aaef8a970752cb08944d2d5"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3985,9 +4054,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51e57976e8a19a18a18e002c6eb12e5769554204238e47ff155fda1809ef0f7"
+checksum = "0404e10f8b07f940be42aa4b8785b4ab42e96d7167ccc92e35d36eee040309c2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4010,50 +4079,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9c1b1c56676f6a50ecd2bb5c75b13de8097c63c684daa69555e742bc7c3d87"
+checksum = "39d75f21122ec134c8bfc8840a8742c0d406a65560fb9716b23800bd7cfd6ae5"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
- "wasmtime-wiggle",
  "wiggle",
-]
-
-[[package]]
-name = "wasmtime-wiggle"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1bbcb131716ca1a27300b9ff7d91e1c4e1e273ef27634933d908a9d681a193"
-dependencies = [
- "wasmtime",
- "wasmtime-wiggle-macro",
- "wiggle",
- "wiggle-borrow",
-]
-
-[[package]]
-name = "wasmtime-wiggle-macro"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c548467efc78fbdb9b5e558b2ee7142621ec14a30f6f82ff18c2a36a7f4507e0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wiggle-generate",
- "witx",
-]
-
-[[package]]
-name = "wast"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d04fe175c7f78214971293e7d8875673804e736092206a3a4544dbc12811c1b"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -4066,19 +4100,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "wat"
-version = "1.0.37"
+name = "wast"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec280a739b69173e0ffd12c1658507996836ba4e992ed9bc1e5385a0bd72a02"
+checksum = "9bc7b9a76845047ded00e031754ff410afee0d50fbdf62b55bdeecd245063d68"
 dependencies = [
- "wast 35.0.2",
+ "leb128",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2cc8d9a69d1ab28a41d9149bb06bb927aba8fc9d56625f8b597a564c83f50"
+dependencies = [
+ "wast 37.0.0",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4120,32 +4163,24 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9665f60d7e1f59c9ee9b09355b800c9d72c14c7b7216115f5a9f9e40fb203d62"
+checksum = "79ca01f1388a549eb3eaa221a072c3cfd3e383618ec6b423e82f2734ee28dd40"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bitflags",
  "thiserror",
  "tracing",
+ "wasmtime",
  "wiggle-macro",
- "witx",
-]
-
-[[package]]
-name = "wiggle-borrow"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1318f02c7d38d591986b978b5da75edabcf1d841929f57d58fc3c4ecebefb8cb"
-dependencies = [
- "wiggle",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5c3eda0ea38a5263bcb350e5cb932f9c9a1978c10dcf9944cad0f6b83d85eb"
+checksum = "544fd41029c33b179656ab1674cd813db7cd473f38f1976ae6e08effb46dd269"
 dependencies = [
  "anyhow",
  "heck",
@@ -4158,9 +4193,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d6175e622c766710a1fa3eb0e06ac05d4f7ef4b91f4e85a54c0f0679b7c07"
+checksum = "9e31ae77a274c9800e6f1342fa4a6dde5e2d72eb9d9b2e0418781be6efc35b58"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4221,14 +4256,14 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4a58e03db38d5e0762afc768ac9abacf826de59602b0a1dfa1b9099f03388e"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
 dependencies = [
  "anyhow",
  "log",
  "thiserror",
- "wast 33.0.0",
+ "wast 35.0.2",
 ]
 
 [[package]]
@@ -4244,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,17 +374,22 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 [[package]]
 name = "burrego"
 version = "0.1.1"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#be4aa31fe447695a93462a6f944653fb200fe97a"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#ae5108cc7937b305f44764827bc17597d5d2ab8a"
 dependencies = [
  "anyhow",
+ "base64 0.13.0",
  "clap",
  "gtmpl",
  "gtmpl_value",
  "lazy_static",
+ "regex",
+ "semver 1.0.4",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tracing",
  "tracing-subscriber",
+ "url 2.2.2",
  "wasmtime",
 ]
 
@@ -1688,9 +1693,11 @@ dependencies = [
  "anyhow",
  "clap",
  "directories",
+ "itertools",
  "k8s-openapi",
  "kube",
  "kubewarden-policy-sdk",
+ "lazy_static",
  "mdcat",
  "policy-evaluator",
  "policy-fetcher",
@@ -2293,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "policy-evaluator"
 version = "0.1.19"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#be4aa31fe447695a93462a6f944653fb200fe97a"
+source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#ae5108cc7937b305f44764827bc17597d5d2ab8a"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,13 +374,16 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 [[package]]
 name = "burrego"
 version = "0.1.1"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#ae5108cc7937b305f44764827bc17597d5d2ab8a"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.0#01548909206cbbc6ce8cf7321ca3596aa72cfb9b"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
+ "chrono",
+ "chrono-tz",
  "clap",
  "gtmpl",
  "gtmpl_value",
+ "json-patch",
  "lazy_static",
  "regex",
  "semver 1.0.4",
@@ -526,6 +529,16 @@ dependencies = [
  "serde",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+dependencies = [
+ "chrono",
+ "parse-zoneinfo",
 ]
 
 [[package]]
@@ -1688,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2190,6 +2203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,8 +2321,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.1.19"
-source = "git+https://github.com/kubewarden/policy-evaluator?branch=opa#ae5108cc7937b305f44764827bc17597d5d2ab8a"
+version = "0.2.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.0#01548909206cbbc6ce8cf7321ca3596aa72cfb9b"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ edition = "2018"
 anyhow = "1.0"
 clap = "2.33.3"
 directories = "3.0.2"
+itertools = "0.10.1"
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
 kube = "0.51.0"
 kubewarden-policy-sdk = "0.2.3"
+lazy_static = "1.4.0"
 mdcat = "0.22"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", branch = "opa" }
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.13" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20
 kube = "0.51.0"
 kubewarden-policy-sdk = "0.2.3"
 mdcat = "0.22"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.1.19" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", branch = "opa" }
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.13" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "0.1.10"
+version = "0.2.0"
 authors = [
         "Flavio Castelli <fcastelli@suse.com>",
         "Rafael Fernández López <rfernandezlopez@suse.com>",
@@ -20,7 +20,7 @@ kube = "0.51.0"
 kubewarden-policy-sdk = "0.2.3"
 lazy_static = "1.4.0"
 mdcat = "0.22"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", branch = "opa" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.0" }
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.13" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version= "0.2", features = ["fmt"] }
 url = "2.2.0"
 validator = { version = "0.13", features = ["derive"] }
 walrus = "0.19.0"
+wasmparser = "0.80.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use kubewarden_policy_sdk::metadata::ProtocolVersion;
 use policy_evaluator::{
-    constants::*, policy_evaluator::PolicyEvaluator, policy_metadata::Metadata,
+    constants::*,
+    policy_evaluator::{PolicyEvaluator, PolicyExecutionMode},
+    policy_metadata::Metadata,
 };
 use std::fs::File;
 use std::path::PathBuf;
@@ -20,6 +22,7 @@ fn protocol_detector(wasm_path: PathBuf) -> Result<ProtocolVersion> {
     let policy_evaluator = PolicyEvaluator::from_file(
         String::from(wasm_path.to_string_lossy()),
         wasm_path.as_path(),
+        PolicyExecutionMode::KubewardenWapc,
         None,
     )?;
     policy_evaluator

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -19,7 +19,7 @@ pub(crate) fn write_annotation(
 }
 
 fn protocol_detector(wasm_path: PathBuf) -> Result<ProtocolVersion> {
-    let policy_evaluator = PolicyEvaluator::from_file(
+    let mut policy_evaluator = PolicyEvaluator::from_file(
         String::from(wasm_path.to_string_lossy()),
         wasm_path.as_path(),
         PolicyExecutionMode::KubewardenWapc,

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,10 +1,7 @@
+use crate::backend::{Backend, BackendDetector};
 use anyhow::{anyhow, Result};
 use kubewarden_policy_sdk::metadata::ProtocolVersion;
-use policy_evaluator::{
-    constants::*,
-    policy_evaluator::{PolicyEvaluator, PolicyExecutionMode},
-    policy_metadata::Metadata,
-};
+use policy_evaluator::{constants::*, policy_metadata::Metadata};
 use std::fs::File;
 use std::path::PathBuf;
 use validator::Validate;
@@ -14,33 +11,30 @@ pub(crate) fn write_annotation(
     metadata_path: PathBuf,
     destination: PathBuf,
 ) -> Result<()> {
-    let metadata = prepare_metadata(wasm_path.clone(), metadata_path, protocol_detector)?;
+    let backend_detector = BackendDetector::default();
+    let metadata = prepare_metadata(wasm_path.clone(), metadata_path, backend_detector)?;
     write_annotated_wasm_file(wasm_path, destination, metadata)
-}
-
-fn protocol_detector(wasm_path: PathBuf) -> Result<ProtocolVersion> {
-    let mut policy_evaluator = PolicyEvaluator::from_file(
-        String::from(wasm_path.to_string_lossy()),
-        wasm_path.as_path(),
-        PolicyExecutionMode::KubewardenWapc,
-        None,
-    )?;
-    policy_evaluator
-        .protocol_version()
-        .map_err(|e| anyhow!("Cannot compute ProtocolVersion used by the policy: {:?}", e))
 }
 
 fn prepare_metadata(
     wasm_path: PathBuf,
     metadata_path: PathBuf,
-    detect_protocol_func: impl Fn(PathBuf) -> Result<ProtocolVersion>,
+    backend_detector: BackendDetector,
 ) -> Result<Metadata> {
-    let metadata_file = File::open(metadata_path)?;
-    let mut metadata: Metadata = serde_yaml::from_reader(&metadata_file)?;
+    let metadata_file =
+        File::open(metadata_path).map_err(|e| anyhow!("Error opening metadata file: {}", e))?;
+    let mut metadata: Metadata = serde_yaml::from_reader(&metadata_file)
+        .map_err(|e| anyhow!("Error unmarshalling metadata {}", e))?;
 
-    let protocol_version = detect_protocol_func(wasm_path)?;
+    let backend = backend_detector.detect(wasm_path, &metadata)?;
 
-    metadata.protocol_version = Some(protocol_version);
+    match backend {
+        Backend::Opa => metadata.protocol_version = Some(ProtocolVersion::Unknown),
+        Backend::OpaGatekeeper => metadata.protocol_version = Some(ProtocolVersion::Unknown),
+        Backend::KubewardenWapc(protocol_version) => {
+            metadata.protocol_version = Some(protocol_version)
+        }
+    };
 
     let mut annotations = metadata.annotations.unwrap_or_default();
     annotations.insert(
@@ -85,6 +79,14 @@ mod tests {
         Ok(ProtocolVersion::V1)
     }
 
+    fn mock_rego_policy_detector_true(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn mock_rego_policy_detector_false(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(false)
+    }
+
     #[test]
     fn test_kwctl_version_is_added_to_already_populated_annotations() -> Result<()> {
         let dir = tempdir()?;
@@ -109,10 +111,14 @@ mod tests {
 
         write!(file, "{}", raw_metadata)?;
 
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_false,
+            mock_protocol_version_detector_v1,
+        );
         let metadata = prepare_metadata(
             PathBuf::from("irrelevant.wasm"),
             file_path,
-            mock_protocol_version_detector_v1,
+            backend_detector,
         )?;
         let annotations = metadata.annotations.unwrap();
 
@@ -154,10 +160,14 @@ mod tests {
 
         write!(file, "{}", raw_metadata)?;
 
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_false,
+            mock_protocol_version_detector_v1,
+        );
         let metadata = prepare_metadata(
             PathBuf::from("irrelevant.wasm"),
             file_path,
-            mock_protocol_version_detector_v1,
+            backend_detector,
         )?;
         let annotations = metadata.annotations.unwrap();
 
@@ -189,21 +199,65 @@ mod tests {
           resources: ["pods"]
           operations: ["CREATE", "UPDATE"]
         mutating: false
+        executionMode: kubewarden-wapc
         "#
         );
 
         write!(file, "{}", raw_metadata)?;
 
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_false,
+            mock_protocol_version_detector_v1,
+        );
         let metadata = prepare_metadata(
             PathBuf::from("irrelevant.wasm"),
             file_path,
-            mock_protocol_version_detector_v1,
+            backend_detector,
         )?;
         let annotations = metadata.annotations.unwrap();
 
         assert_eq!(
             annotations.get(KUBEWARDEN_ANNOTATION_KWCTL_VERSION),
             Some(&String::from(env!("CARGO_PKG_VERSION"))),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_final_metadata_for_a_rego_policy() -> Result<()> {
+        let dir = tempdir()?;
+
+        let file_path = dir.path().join("metadata.yml");
+        let mut file = File::create(file_path.clone())?;
+
+        let raw_metadata = String::from(
+            r#"
+        rules:
+        - apiGroups: [""]
+          apiVersions: ["v1"]
+          resources: ["pods"]
+          operations: ["CREATE", "UPDATE"]
+        mutating: false
+        executionMode: opa
+        "#,
+        );
+
+        write!(file, "{}", raw_metadata)?;
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_true,
+            mock_protocol_version_detector_v1,
+        );
+        let metadata = prepare_metadata(
+            PathBuf::from("irrelevant.wasm"),
+            file_path,
+            backend_detector,
+        );
+        assert!(metadata.is_ok());
+        assert_eq!(
+            metadata.unwrap().protocol_version,
+            Some(ProtocolVersion::Unknown)
         );
 
         Ok(())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,168 @@
+use anyhow::{anyhow, Result};
+use kubewarden_policy_sdk::metadata::ProtocolVersion;
+use policy_evaluator::{
+    policy_evaluator::{PolicyEvaluator, PolicyExecutionMode},
+    policy_metadata::Metadata,
+};
+use std::path::PathBuf;
+
+pub(crate) enum Backend {
+    Opa,
+    OpaGatekeeper,
+    KubewardenWapc(ProtocolVersion),
+}
+
+type KubewardenProtocolDetectorFn = fn(PathBuf) -> Result<ProtocolVersion>;
+type RegoDetectorFn = fn(PathBuf) -> Result<bool>;
+
+// Looks at the Wasm module pointed by `wasm_path` and return whether it was generaed by a Rego
+// policy
+//
+// The code looks at the export symbols offered by the Wasm module.
+// Having at least one symbol that starts with the `opa_` prefix leads
+// the policy to be considered a Rego-based one.
+fn rego_policy_detector(wasm_path: PathBuf) -> Result<bool> {
+    let data: Vec<u8> = std::fs::read(wasm_path)?;
+    for payload in wasmparser::Parser::new(0).parse_all(&data) {
+        if let wasmparser::Payload::ExportSection(s) = payload? {
+            for export in s {
+                if export?.field.starts_with("opa_") {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+fn kubewarden_protocol_detector(wasm_path: PathBuf) -> Result<ProtocolVersion> {
+    let mut policy_evaluator = PolicyEvaluator::from_file(
+        String::from(wasm_path.to_string_lossy()),
+        wasm_path.as_path(),
+        PolicyExecutionMode::KubewardenWapc,
+        None,
+    )?;
+    policy_evaluator
+        .protocol_version()
+        .map_err(|e| anyhow!("Cannot compute ProtocolVersion used by the policy: {:?}", e))
+}
+
+pub(crate) struct BackendDetector {
+    kubewarden_protocol_detector_func: KubewardenProtocolDetectorFn,
+    rego_detector_func: RegoDetectorFn,
+}
+
+impl Default for BackendDetector {
+    fn default() -> Self {
+        BackendDetector {
+            kubewarden_protocol_detector_func: kubewarden_protocol_detector,
+            rego_detector_func: rego_policy_detector,
+        }
+    }
+}
+
+impl BackendDetector {
+    #[allow(dead_code)]
+    /// This method is intended to be used by unit tests
+    pub(crate) fn new(
+        rego_detector_func: RegoDetectorFn,
+        kubewarden_protocol_detector_func: KubewardenProtocolDetectorFn,
+    ) -> Self {
+        BackendDetector {
+            kubewarden_protocol_detector_func,
+            rego_detector_func,
+        }
+    }
+
+    pub(crate) fn detect(&self, wasm_path: PathBuf, metadata: &Metadata) -> Result<Backend> {
+        let is_rego_policy = (self.rego_detector_func)(wasm_path.clone()).map_err(|e| {
+            anyhow!(
+                "Error while checking if the policy has been created using Opa/Gatekeeper: {}",
+                e
+            )
+        })?;
+        match metadata.execution_mode {
+            PolicyExecutionMode::Opa => {
+                if is_rego_policy {
+                    Ok(Backend::Opa)
+                } else {
+                    Err(anyhow!(
+                        "Wrong value inside of policy's metatada for 'executionMode'. The policy has not been created using Rego"
+                    ))
+                }
+            }
+            PolicyExecutionMode::OpaGatekeeper => {
+                if is_rego_policy {
+                    Ok(Backend::OpaGatekeeper)
+                } else {
+                    Err(anyhow!(
+                        "Wrong value inside of policy's metatada for 'executionMode'. The policy has not been created using Rego"
+                    ))
+                }
+            }
+            PolicyExecutionMode::KubewardenWapc => {
+                if is_rego_policy {
+                    Err(anyhow!(
+                        "Wrong value inside of policy's metatada for 'executionMode'. This policy has been created using Rego"
+                    ))
+                } else {
+                    let protocol_version = (self.kubewarden_protocol_detector_func)(wasm_path)
+                        .map_err(|e| {
+                            anyhow!("Error while detecting Kubewarden protocol version: {:?}", e)
+                        })?;
+                    Ok(Backend::KubewardenWapc(protocol_version))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_protocol_version_detector_v1(_wasm_path: PathBuf) -> Result<ProtocolVersion> {
+        Ok(ProtocolVersion::V1)
+    }
+
+    fn mock_rego_policy_detector_true(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn mock_rego_policy_detector_false(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(false)
+    }
+
+    #[test]
+    fn test_execution_mode_cannot_be_kubewarden_for_a_rego_policy() {
+        let metadata = Metadata {
+            execution_mode: PolicyExecutionMode::KubewardenWapc,
+            ..Default::default()
+        };
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_true,
+            mock_protocol_version_detector_v1,
+        );
+        let backend = backend_detector.detect(PathBuf::from("irrelevant.wasm"), &metadata);
+        assert!(backend.is_err());
+    }
+
+    #[test]
+    fn test_execution_mode_cannot_be_opa_or_gatekeeper_for_a_kubewarden_policy() {
+        for execution_mode in vec![PolicyExecutionMode::Opa, PolicyExecutionMode::OpaGatekeeper] {
+            let metadata = Metadata {
+                execution_mode,
+                ..Default::default()
+            };
+
+            let backend_detector = BackendDetector::new(
+                mock_rego_policy_detector_false,
+                mock_protocol_version_detector_v1,
+            );
+            let backend = backend_detector.detect(PathBuf::from("irrelevant.wasm"), &metadata);
+            assert!(backend.is_err());
+        }
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,7 @@ pub fn build_cli() -> clap::App<'static, 'static> {
              (@arg ("request-path"): * -r --("request-path") +takes_value "File containing the Kubernetes admission request object in JSON format")
              (@arg ("settings-path"): -s --("settings-path") +takes_value "File containing the settings for this policy")
              (@arg ("settings-json"): --("settings-json") +takes_value "JSON string containing the settings for this policy")
+             (@arg ("execution-mode"): -e --("execution-mode") +takes_value "The runtime to use to execute this policy")
              (@arg ("uri"): * "Policy URI. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory")
             )
             (@subcommand annotate =>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,27 @@
 use clap::{clap_app, crate_authors, crate_description, crate_name, crate_version, AppSettings};
+use itertools::Itertools;
+use lazy_static::lazy_static;
+use policy_evaluator::burrego::opa::builtins as opa_builtins;
+
+lazy_static! {
+    static ref VERSION_AND_BUILTINS: String = {
+        let builtins: String = opa_builtins::get_builtins()
+            .keys()
+            .sorted()
+            .map(|builtin| format!("  - {}", builtin))
+            .join("\n");
+
+        format!(
+            "{}\n\nOpen Policy Agent/Gatekeeper implemented builtins:\n{}",
+            crate_version!(),
+            builtins,
+        )
+    };
+}
 
 pub fn build_cli() -> clap::App<'static, 'static> {
     clap_app!(
         (crate_name!()) =>
-            (version: crate_version!())
             (author: crate_authors!(",\n"))
             (about: crate_description!())
             (@arg verbose: -v "Increase verbosity")
@@ -62,5 +80,6 @@ pub fn build_cli() -> clap::App<'static, 'static> {
              (@arg ("shell"): * -s --("shell") +takes_value "Shell type: bash, fish, zsh, elvish, powershell")
             )
     )
-    .setting(AppSettings::SubcommandRequiredElseHelp)
+        .long_version(VERSION_AND_BUILTINS.as_str())
+        .setting(AppSettings::SubcommandRequiredElseHelp)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
     match matches.subcommand_name() {
         Some("policies") => policies::list(),
         Some("pull") => {
-            if let Some(ref matches) = matches.subcommand_matches("pull") {
+            if let Some(matches) = matches.subcommand_matches("pull") {
                 let uri = matches.value_of("uri").unwrap();
                 let destination = matches
                     .value_of("output-path")
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Some("push") => {
-            if let Some(ref matches) = matches.subcommand_matches("push") {
+            if let Some(matches) = matches.subcommand_matches("push") {
                 let (sources, docker_config) = remote_server_options(matches)?;
                 let wasm_uri = crate::utils::map_path_to_uri(matches.value_of("policy").unwrap())?;
                 let wasm_path = crate::utils::wasm_path(wasm_uri.as_str())?;
@@ -117,14 +117,14 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Some("rm") => {
-            if let Some(ref matches) = matches.subcommand_matches("rm") {
+            if let Some(matches) = matches.subcommand_matches("rm") {
                 let uri = matches.value_of("uri").unwrap();
                 rm::rm(uri)?;
             }
             Ok(())
         }
         Some("run") => {
-            if let Some(ref matches) = matches.subcommand_matches("run") {
+            if let Some(matches) = matches.subcommand_matches("run") {
                 let uri = matches.value_of("uri").unwrap();
                 let request = match matches.value_of("request-path").unwrap() {
                     "-" => {
@@ -168,7 +168,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Some("annotate") => {
-            if let Some(ref matches) = matches.subcommand_matches("annotate") {
+            if let Some(matches) = matches.subcommand_matches("annotate") {
                 let wasm_path = matches
                     .value_of("wasm-path")
                     .map(|output| PathBuf::from_str(output).unwrap())
@@ -186,7 +186,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Some("inspect") => {
-            if let Some(ref matches) = matches.subcommand_matches("inspect") {
+            if let Some(matches) = matches.subcommand_matches("inspect") {
                 let uri = matches.value_of("uri").unwrap();
                 let output = inspect::OutputType::try_from(matches.value_of("output"))?;
 
@@ -195,7 +195,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Some("manifest") => {
-            if let Some(ref matches) = matches.subcommand_matches("manifest") {
+            if let Some(matches) = matches.subcommand_matches("manifest") {
                 let uri = matches.value_of("uri").unwrap();
                 let resource_type = matches.value_of("type").unwrap();
                 if matches.is_present("settings-path") && matches.is_present("settings-json") {
@@ -223,7 +223,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Some("completions") => {
-            if let Some(ref matches) = matches.subcommand_matches("completions") {
+            if let Some(matches) = matches.subcommand_matches("completions") {
                 let shell = match matches.value_of("shell").unwrap() {
                     "bash" => clap::Shell::Bash,
                     "fish" => clap::Shell::Fish,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use tracing::debug;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
-use policy_evaluator::{policy_evaluator::PolicyExecutionMode, policy_metadata::Metadata};
+use policy_evaluator::policy_evaluator::PolicyExecutionMode;
 use policy_fetcher::registry::config::{read_docker_config_json_file, DockerConfig};
 use policy_fetcher::sources::{read_sources_file, Sources};
 use policy_fetcher::store::DEFAULT_ROOT;
@@ -103,18 +103,9 @@ async fn main() -> Result<()> {
                     "policy push"
                 );
 
-                let policy = fs::read(&wasm_path)?;
                 let force = matches.is_present("force");
-                let metadata = Metadata::from_path(&wasm_path)?;
-                if metadata.is_none() {
-                    if force {
-                        eprintln!("Warning: pushing a non-annotated policy!");
-                    } else {
-                        return Err(anyhow!("Cannot push a policy that is not annotated. Use `annotate` command or `push --force`"));
-                    }
-                }
 
-                push::push(&policy, &uri, docker_config, sources).await?;
+                push::push(wasm_path, &uri, docker_config, sources, force).await?;
             };
             println!("Policy successfully pushed");
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ use policy_fetcher::store::DEFAULT_ROOT;
 use policy_fetcher::PullDestination;
 
 mod annotate;
+mod backend;
 mod cli;
 mod completions;
 mod inspect;

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,14 +1,46 @@
-use anyhow::Result;
-
+use anyhow::{anyhow, Result};
+use policy_evaluator::policy_metadata::Metadata;
 use policy_fetcher::{registry::config::DockerConfig, registry::Registry, sources::Sources};
+use std::{fs, path::PathBuf};
+
+use crate::backend::BackendDetector;
 
 pub(crate) async fn push(
-    policy: &[u8],
+    wasm_path: PathBuf,
     uri: &str,
     docker_config: Option<DockerConfig>,
     sources: Option<Sources>,
+    force: bool,
 ) -> Result<()> {
+    match Metadata::from_path(&wasm_path)? {
+        Some(_) => {}
+        None => {
+            if force {
+                let backend_detector = BackendDetector::default();
+                if can_be_force_pushed_without_metadata(backend_detector, wasm_path.clone())? {
+                    eprintln!("Warning: pushing a non-annotated policy!");
+                } else {
+                    return Err(anyhow!("Rego policies cannot be pushed without metadata"));
+                }
+            } else {
+                return Err(anyhow!("Cannot push a policy that is not annotated. Use `annotate` command or `push --force`"));
+            }
+        }
+    };
+
+    let policy = fs::read(&wasm_path).map_err(|e| anyhow!("Cannot open policy file: {:?}", e))?;
     Registry::new(&docker_config)
-        .push(policy, uri, &sources)
+        .push(&policy, uri, &sources)
         .await
+}
+
+fn can_be_force_pushed_without_metadata(
+    backend_detector: BackendDetector,
+    wasm_path: PathBuf,
+) -> Result<bool> {
+    let is_rego = backend_detector
+        .is_rego_policy(&wasm_path)
+        .map_err(|e| anyhow!("Cannot understand if the policy is based on Rego: {:?}", e))?;
+
+    Ok(!is_rego)
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -9,6 +9,6 @@ pub(crate) async fn push(
     sources: Option<Sources>,
 ) -> Result<()> {
     Registry::new(&docker_config)
-        .push(&policy, uri, &sources)
+        .push(policy, uri, &sources)
         .await
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -7,11 +7,13 @@ use policy_evaluator::{
     policy_metadata::Metadata,
 };
 use policy_fetcher::{registry::config::DockerConfig, sources::Sources};
+use std::path::Path;
 
-use crate::pull;
+use crate::{backend::BackendDetector, pull};
 
 pub(crate) async fn pull_and_run(
     uri: &str,
+    user_execution_mode: Option<PolicyExecutionMode>,
     docker_config: Option<DockerConfig>,
     sources: Option<Sources>,
     request: &str,
@@ -44,13 +46,21 @@ pub(crate) async fn pull_and_run(
                 .map_err(|e| anyhow!("could not initialize a cluster context: {}", e))?;
         }
     }
-    let policy_id = read_policy_title_from_metadata(metadata).unwrap_or_else(|| uri.clone());
+    let policy_id = read_policy_title_from_metadata(&metadata).unwrap_or_else(|| uri.clone());
 
     let request = serde_json::from_str::<serde_json::Value>(request)?;
+
+    let execution_mode = determine_execution_mode(
+        metadata.clone(),
+        user_execution_mode,
+        BackendDetector::default(),
+        policy_path,
+    )?;
+
     let mut policy_evaluator = PolicyEvaluator::from_file(
         policy_id,
         policy_path,
-        PolicyExecutionMode::KubewardenWapc,
+        execution_mode,
         settings.map_or(Ok(None), |settings| {
             if settings.is_empty() {
                 Ok(None)
@@ -96,7 +106,7 @@ pub(crate) async fn pull_and_run(
     Ok(())
 }
 
-fn read_policy_title_from_metadata(metadata: Option<Metadata>) -> Option<String> {
+fn read_policy_title_from_metadata(metadata: &Option<Metadata>) -> Option<String> {
     match metadata {
         Some(ref metadata) => match metadata.annotations {
             Some(ref annotations) => annotations
@@ -105,5 +115,306 @@ fn read_policy_title_from_metadata(metadata: Option<Metadata>) -> Option<String>
             None => None,
         },
         None => None,
+    }
+}
+
+fn determine_execution_mode(
+    metadata: Option<Metadata>,
+    user_execution_mode: Option<PolicyExecutionMode>,
+    backend_detector: BackendDetector,
+    wasm_path: &Path,
+) -> Result<PolicyExecutionMode> {
+    // Desired behaviour, as documented here: https://github.com/kubewarden/kwctl/issues/58
+    //
+    // When a wasm file is annotated:
+    // *  if the user didn't specify a runtime to be used: kwctl will use
+    //    this information to pick the right runtime
+    // *  if the user specified a runtime to be used: we error out if the
+    //    value provided by the user does not match with the one
+    //    inside of the wasm metadata
+    //
+    //When a wasm file is NOT annotated:
+    // * If the user didn't specify a runtime to be used:
+    //   - We do a quick heuristic to understand if the policy is Rego base:
+    //      - If we do not find the OPA ABI constant -> we assume the policy is
+    //        a kubewarden one
+    //      - If we do find the policy was built using Rego, kwctl exists with
+    //        an error because the user has to specify whether this is a OPA
+    //        or Gatekeeper policy (that influences how kwctl builds the input and
+    //        data variables)
+    // * If the user does provide the --runtime-mode flag: we use the runtime
+    //   the user specified
+
+    match metadata {
+        Some(metadata) => {
+            // metadata is set
+            match user_execution_mode {
+                Some(usermode) => {
+                    // metadata AND user execution mode are set
+                    if usermode != metadata.execution_mode {
+                        Err(anyhow!(
+                        "The policy execution mode specified via CLI flag is different from the one reported inside of policy's metadata. Metadata reports {} instead of {}",
+                        metadata.execution_mode,
+                        usermode)
+                    )
+                    } else {
+                        Ok(metadata.execution_mode)
+                    }
+                }
+                None => {
+                    // only metadata is set
+                    Ok(metadata.execution_mode)
+                }
+            }
+        }
+        None => {
+            // metadata is not set
+            let is_rego_policy = backend_detector.is_rego_policy(&wasm_path.to_path_buf())?;
+            match user_execution_mode {
+                Some(PolicyExecutionMode::Opa) => {
+                    if is_rego_policy {
+                        Ok(PolicyExecutionMode::Opa)
+                    } else {
+                        Err(anyhow!("The policy has not been created with Rego, the policy execution mode specified via CLI flag is wrong"))
+                    }
+                }
+                Some(PolicyExecutionMode::OpaGatekeeper) => {
+                    if is_rego_policy {
+                        Ok(PolicyExecutionMode::OpaGatekeeper)
+                    } else {
+                        Err(anyhow!("The policy has not been created with Rego, the policy execution mode specified via CLI flag is wrong"))
+                    }
+                }
+                Some(PolicyExecutionMode::KubewardenWapc) => {
+                    if !is_rego_policy {
+                        Ok(PolicyExecutionMode::KubewardenWapc)
+                    } else {
+                        Err(anyhow!("The policy has been created with Rego, the policy execution mode specified via CLI flag is wrong"))
+                    }
+                }
+                None => {
+                    if is_rego_policy {
+                        Err(anyhow!("The policy has been created with Rego, please specify which Opa runtime has to be used"))
+                    } else {
+                        Ok(PolicyExecutionMode::KubewardenWapc)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kubewarden_policy_sdk::metadata::ProtocolVersion;
+    use std::path::PathBuf;
+
+    fn mock_protocol_version_detector_v1(_wasm_path: PathBuf) -> Result<ProtocolVersion> {
+        Ok(ProtocolVersion::V1)
+    }
+
+    fn mock_rego_policy_detector_true(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn mock_rego_policy_detector_false(_wasm_path: PathBuf) -> Result<bool> {
+        Ok(false)
+    }
+
+    #[test]
+    fn test_determine_execution_mode_metadata_and_user_mode_are_set_but_have_different_values() {
+        let user_execution_mode = Some(PolicyExecutionMode::Opa);
+        let metadata = Some(Metadata {
+            execution_mode: PolicyExecutionMode::KubewardenWapc,
+            ..Default::default()
+        });
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_true,
+            mock_protocol_version_detector_v1,
+        );
+
+        let mode = determine_execution_mode(
+            metadata,
+            user_execution_mode,
+            backend_detector,
+            &PathBuf::from("irrelevant.wasm").to_path_buf(),
+        );
+        assert!(mode.is_err());
+    }
+
+    #[test]
+    fn test_determine_execution_mode_metadata_and_user_mode_are_set_and_have_same_value() {
+        let user_execution_mode = Some(PolicyExecutionMode::Opa);
+        let metadata = Some(Metadata {
+            execution_mode: PolicyExecutionMode::Opa,
+            ..Default::default()
+        });
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_true,
+            mock_protocol_version_detector_v1,
+        );
+
+        let mode = determine_execution_mode(
+            metadata,
+            user_execution_mode,
+            backend_detector,
+            &PathBuf::from("irrelevant.wasm").to_path_buf(),
+        );
+        assert!(mode.is_ok());
+        assert_eq!(PolicyExecutionMode::Opa, mode.unwrap());
+    }
+
+    #[test]
+    fn test_determine_execution_mode_metadata_is_set_and_user_mode_is_not_set() {
+        let user_execution_mode = None;
+        let expected_execution_mode = PolicyExecutionMode::Opa;
+        let metadata = Some(Metadata {
+            execution_mode: expected_execution_mode.clone(),
+            ..Default::default()
+        });
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_true,
+            mock_protocol_version_detector_v1,
+        );
+
+        let mode = determine_execution_mode(
+            metadata,
+            user_execution_mode,
+            backend_detector,
+            &PathBuf::from("irrelevant.wasm").to_path_buf(),
+        );
+        assert!(mode.is_ok());
+        assert_eq!(expected_execution_mode, mode.unwrap());
+    }
+
+    #[test]
+    fn test_determine_execution_mode_metadata_is_not_set_and_user_mode_is_set_but_the_user_value_is_wrong(
+    ) {
+        for mode in vec![
+            PolicyExecutionMode::Opa,
+            PolicyExecutionMode::OpaGatekeeper,
+            PolicyExecutionMode::KubewardenWapc,
+        ] {
+            let user_execution_mode = Some(mode.clone());
+            let metadata = None;
+
+            let backend_detector = match mode {
+                PolicyExecutionMode::Opa => BackendDetector::new(
+                    mock_rego_policy_detector_false,
+                    mock_protocol_version_detector_v1,
+                ),
+                PolicyExecutionMode::OpaGatekeeper => BackendDetector::new(
+                    mock_rego_policy_detector_false,
+                    mock_protocol_version_detector_v1,
+                ),
+                PolicyExecutionMode::KubewardenWapc => BackendDetector::new(
+                    mock_rego_policy_detector_true,
+                    mock_protocol_version_detector_v1,
+                ),
+            };
+
+            let actual = determine_execution_mode(
+                metadata,
+                user_execution_mode,
+                backend_detector,
+                &PathBuf::from("irrelevant.wasm").to_path_buf(),
+            );
+            assert!(
+                actual.is_err(),
+                "Expected to fail when user specified mode to be {}",
+                mode
+            );
+        }
+    }
+
+    #[test]
+    fn test_determine_execution_mode_metadata_is_not_set_and_user_mode_is_set_and_the_user_value_is_right(
+    ) {
+        for mode in vec![
+            PolicyExecutionMode::Opa,
+            PolicyExecutionMode::OpaGatekeeper,
+            PolicyExecutionMode::KubewardenWapc,
+        ] {
+            let user_execution_mode = Some(mode.clone());
+            let metadata = None;
+
+            let backend_detector = match mode {
+                PolicyExecutionMode::Opa => BackendDetector::new(
+                    mock_rego_policy_detector_true,
+                    mock_protocol_version_detector_v1,
+                ),
+                PolicyExecutionMode::OpaGatekeeper => BackendDetector::new(
+                    mock_rego_policy_detector_true,
+                    mock_protocol_version_detector_v1,
+                ),
+                PolicyExecutionMode::KubewardenWapc => BackendDetector::new(
+                    mock_rego_policy_detector_false,
+                    mock_protocol_version_detector_v1,
+                ),
+            };
+
+            let actual = determine_execution_mode(
+                metadata,
+                user_execution_mode,
+                backend_detector,
+                &PathBuf::from("irrelevant.wasm").to_path_buf(),
+            );
+            assert!(
+                actual.is_ok(),
+                "Expected to be ok when user specified mode to be {}",
+                mode
+            );
+            let actual = actual.unwrap();
+            assert_eq!(
+                actual, mode,
+                "Expected to obtain {}, got {} instead",
+                mode, actual,
+            );
+        }
+    }
+
+    #[test]
+    fn test_determine_execution_mode_metadata_is_not_set_and_user_mode_is_not_set_and_policy_is_rego(
+    ) {
+        let user_execution_mode = None;
+        let metadata = None;
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_true,
+            mock_protocol_version_detector_v1,
+        );
+
+        let actual = determine_execution_mode(
+            metadata,
+            user_execution_mode,
+            backend_detector,
+            &PathBuf::from("irrelevant.wasm").to_path_buf(),
+        );
+        assert!(actual.is_err());
+    }
+
+    #[test]
+    fn test_determine_execution_mode_metadata_is_not_set_and_user_mode_is_not_set_and_policy_is_not_rego(
+    ) {
+        let user_execution_mode = None;
+        let metadata = None;
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_false,
+            mock_protocol_version_detector_v1,
+        );
+
+        let actual = determine_execution_mode(
+            metadata,
+            user_execution_mode,
+            backend_detector,
+            &PathBuf::from("irrelevant.wasm").to_path_buf(),
+        );
+        assert!(actual.is_ok());
+        assert_eq!(actual.unwrap(), PolicyExecutionMode::KubewardenWapc);
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -3,7 +3,7 @@ use kube::Client;
 use policy_evaluator::{
     cluster_context::ClusterContext,
     constants::*,
-    policy_evaluator::{PolicyEvaluator, ValidateRequest},
+    policy_evaluator::{PolicyEvaluator, PolicyExecutionMode, ValidateRequest},
     policy_metadata::Metadata,
 };
 use policy_fetcher::{registry::config::DockerConfig, sources::Sources};
@@ -46,10 +46,11 @@ pub(crate) async fn pull_and_run(
     }
     let policy_id = read_policy_title_from_metadata(metadata).unwrap_or_else(|| uri.clone());
 
-    let request = serde_json::from_str::<serde_json::Value>(&request)?;
-    let policy_evaluator = PolicyEvaluator::from_file(
+    let request = serde_json::from_str::<serde_json::Value>(request)?;
+    let mut policy_evaluator = PolicyEvaluator::from_file(
         policy_id,
         policy_path,
+        PolicyExecutionMode::KubewardenWapc,
         settings.map_or(Ok(None), |settings| {
             if settings.is_empty() {
                 Ok(None)


### PR DESCRIPTION
Finally merge the whole `opa` branch. This allows to handle policies written using Rego