### PR TITLE
Handle the new sources configuration format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,8 +2346,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.1.14"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.14#52277963c3bc47530d8724ddcfb01301535b50cb"
+version = "0.1.15"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.15#3ae53aecd00175951ff7e3f25af76361a9ce4c83"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ kubewarden-policy-sdk = "0.2.3"
 lazy_static = "1.4.0"
 mdcat = "0.22"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.1" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.14" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.15" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.8", default-features = false }


### PR DESCRIPTION
Update to the lastest release of policy-fetcher to support the new sources.yaml format.
