### PR TITLE
Implement the verify sub-command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64ct"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +775,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +836,15 @@ checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
 dependencies = [
  "adler32",
  "byteorder",
+]
+
+[[package]]
+name = "der"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -882,10 +925,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
+name = "ecdsa"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "hmac",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+dependencies = [
+ "crypto-bigint",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -995,6 +1066,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ff"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -1273,6 +1354,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "gtmpl"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1428,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest",
 ]
 
 [[package]]
@@ -1724,6 +1826,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "sigstore 0.0.1 (git+https://github.com/flavio/sigstore-rs?branch=main)",
  "syntect",
  "tempfile",
  "tokio 1.12.0",
@@ -2107,6 +2210,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-distribution"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f50cb73141efc685844c84c98c361429c3a7db550d8d9888af037d93358a7"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hyperx",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio 1.12.0",
+ "tracing",
+ "www-authenticate",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,6 +2306,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2374,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71fb2d401a15271d52aade6d9410fb4ead603a86da5503f92e872e1df790265"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,6 +2431,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+dependencies = [
+ "der",
+ "pem-rfc7468",
+ "spki",
+ "zeroize",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2347,8 +2502,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.1.14"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.14#52277963c3bc47530d8724ddcfb01301535b50cb"
+version = "0.1.16"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.16#b0a55566dc15d95dc97c0386a7e529c4d8e68f3f"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2357,12 +2512,15 @@ dependencies = [
  "base64 0.13.0",
  "directories",
  "lazy_static",
- "oci-distribution",
+ "oci-distribution 0.6.0",
  "reqwest",
  "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
+ "sigstore 0.0.1 (git+https://github.com/flavio/sigstore-rs?tag=v0.0.1)",
+ "tracing",
  "url 2.2.2",
  "walkdir",
 ]
@@ -3001,6 +3159,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "sigstore"
+version = "0.0.1"
+source = "git+https://github.com/flavio/sigstore-rs?tag=v0.0.1#e6d0c16f1cd7644121af0941641aaddab04aa310"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.13.0",
+ "ecdsa",
+ "oci-distribution 0.7.0",
+ "p256",
+ "serde",
+ "serde_json",
+ "tokio 1.12.0",
+ "tracing",
+]
+
+[[package]]
+name = "sigstore"
+version = "0.0.1"
+source = "git+https://github.com/flavio/sigstore-rs?branch=main#e6d0c16f1cd7644121af0941641aaddab04aa310"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.13.0",
+ "ecdsa",
+ "oci-distribution 0.7.0",
+ "p256",
+ "serde",
+ "serde_json",
+ "tokio 1.12.0",
+ "tracing",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,6 +3237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spki"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+dependencies = [
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3262,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -3369,9 +3586,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
  "log",
@@ -3382,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3393,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -4272,6 +4489,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ kubewarden-policy-sdk = "0.2.3"
 lazy_static = "1.4.0"
 mdcat = "0.22"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.3" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.14" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.16" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.8", default-features = false }
@@ -29,6 +29,7 @@ regex = "1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.17"
+sigstore = { git = "https://github.com/flavio/sigstore-rs", branch = "main" }
 sha2 = "0.9.5"
 syntect = "4.5.0"
 tokio-compat-02 = "0.2.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,47 @@ pub fn build_cli() -> clap::App<'static, 'static> {
                 )
         )
         .subcommand(
+            SubCommand::with_name("verify")
+                .about("Verify a Kubewarden policy from a given URI using Sigstore")
+                .arg(
+                    Arg::with_name("docker-config-json-path")
+                    .long("docker-config-json-path")
+                    .takes_value(true)
+                    .help("Path to a Docker config.json-like path. Can be used to indicate registry authentication details")
+                )
+                .arg(
+                    Arg::with_name("sources-path")
+                    .long("sources-path")
+                    .takes_value(true)
+                    .help("YAML file holding source information (https, registry insecure hosts, custom CA's...)")
+                )
+                .arg(
+                    Arg::with_name("key")
+                    .short("k")
+                    .long("key")
+                    .takes_value(true)
+                    .required(true)
+                    .help("Verification key")
+                )
+                .arg(
+                    Arg::with_name("annotations")
+                        .short("a")
+                        .long("annotation")
+                        .value_name("PAIR")
+                        .help("Annotations that have to be satisfied")
+                        .required(false)
+                        .multiple(true)
+                        .number_of_values(1)
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("uri")
+                        .required(true)
+                        .index(1)
+                        .help("Policy URI. Supported schemes: registry://")
+                )
+        )
+        .subcommand(
             SubCommand::with_name("push")
                 .about("Pushes a Kubewarden policy to an OCI registry")
                 .arg(

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,29 @@
+use anyhow::{anyhow, Result};
+use policy_fetcher::registry::config::DockerConfig;
+use policy_fetcher::sources::Sources;
+use policy_fetcher::verify::Verifier;
+use std::io::prelude::*;
+use std::{collections::HashMap, fs::File};
+
+pub(crate) async fn verify(
+    url: &str,
+    docker_config: Option<DockerConfig>,
+    sources: Option<Sources>,
+    annotations: Option<HashMap<String, String>>,
+    key_file: &str,
+) -> Result<()> {
+    let mut pub_key_file =
+        File::open(key_file).map_err(|e| anyhow!("Cannot read verification key file: {:?}", e))?;
+    let mut verification_key = String::new();
+    pub_key_file
+        .read_to_string(&mut verification_key)
+        .map_err(|e| anyhow!("Error reading contents of verification key file {:?}", e))?;
+
+    let mut verifier = Verifier::new(sources);
+    verifier
+        .verify(url, docker_config, annotations, &verification_key)
+        .await?;
+
+    println!("Policy successfully verified");
+    Ok(())
+}


### PR DESCRIPTION
This command verifies the integrity of a policy stored inside of an OCI registry using Sigstore.

If the policy has been downloaded, the code will also ensures nobody tampered the local file.
