### PR TITLE
refactoring: remove sha256 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
  "sigstore 0.0.1 (git+https://github.com/flavio/sigstore-rs?branch=main)",
  "syntect",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.17"
 sigstore = { git = "https://github.com/flavio/sigstore-rs", branch = "main" }
-sha2 = "0.9.5"
 syntect = "4.5.0"
 tokio-compat-02 = "0.2.0"
 tokio = { version = "^1", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ extern crate pretty_bytes;
 #[macro_use]
 extern crate prettytable;
 extern crate serde_yaml;
-extern crate sha2;
 
 use anyhow::{anyhow, Result};
 use clap::ArgMatches;

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -4,7 +4,6 @@ use policy_fetcher::policy::Policy;
 use policy_fetcher::store::Store;
 use pretty_bytes::converter::convert;
 use prettytable::{format, Table};
-use sha2::{Digest, Sha256};
 
 pub(crate) fn list() -> Result<()> {
     if policy_list()?.is_empty() {
@@ -39,10 +38,8 @@ pub(crate) fn list() -> Result<()> {
                 ("unknown", "no")
             };
 
-        let sha256sum = format!(
-            "{:.12x}",
-            Sha256::digest(&std::fs::read(&policy.local_path)?)
-        );
+        let mut sha256sum = policy.digest()?;
+        sha256sum.truncate(12);
 
         let policy_filesystem_metadata = std::fs::metadata(&policy.local_path)?;
 


### PR DESCRIPTION
Leverage the `Policy::digest` method, this allows to remove some code and even a top level dependency of kwctl
