### PR TITLE
tests: Expand `kwctl run` cases, test `kwctl verify`

### DIFF
--- a/e2e-tests/e2e.bats
+++ b/e2e-tests/e2e.bats
@@ -82,32 +82,40 @@ kwctl() {
 }
 
 @test "verify a signed policy from an OCI registry" {
-    kwctl pull -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    kwctl verify -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
-    [ $(expr "$output" : '.*Intending to verify annotations, but no verification keys were passed.*') -ne 0 ]
-    kwctl pull -k test-data/sigstore/cosign1.pub -k test-data/sigstore/cosign2.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    [ $(expr "$output" : '.*The following required arguments were not provided.*') -ne 0 ]
+    kwctl verify -k test-data/sigstore/cosign1.pub -k unexistent-path-to-key.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    [ "$status" -eq 1 ]
+    [ $(expr "$output" : '.*No such file or directory.*') -ne 0 ]
+    kwctl verify -k test-data/sigstore/cosign1.pub -k test-data/sigstore/cosign2.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
     [ $(expr "$output" : '.*Policy successfully verified.*') -ne 0 ]
-    [ $(expr "$output" : '.*Local checksum successfully verified.*') -ne 0 ]
-    kwctl pull -k test-data/sigstore/cosign3.pub registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    kwctl verify -k test-data/sigstore/cosign3.pub registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*The signature object didn'\''t have any layer signed with the given key.*') -ne 0 ]
-    kwctl pull -k test-data/sigstore/cosign2.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    kwctl verify -k test-data/sigstore/cosign2.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*The signature object didn'\''t have any layer signed with the given key.*') -ne 0 ]
     # TODO should return instead: Annotation not satisfied missing_annotation="stable"
 }
 
 @test "pull a signed policy from an OCI registry" {
-    kwctl pull -k test-data/sigstore/cosign1.pub -k test-data/cosign1.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    kwctl pull -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    [ "$status" -eq 1 ]
+    [ $(expr "$output" : '.*Intending to verify annotations, but no verification keys were passed.*') -ne 0 ]
+    kwctl pull -k test-data/sigstore/cosign1.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
     [ $(expr "$output" : '.*Policy successfully verified.*') -ne 0 ]
     [ $(expr "$output" : '.*Local checksum successfully verified.*') -ne 0 ]
 }
 
 @test "execute a signed policy from an OCI registry" {
-    kwctl run -k test-data/sigstore/cosign1.pub -k test-data/cosign1.pub -a env=prod -a stable=true --request-path test-data/privileged-pod.json registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    kwctl run -k test-data/sigstore/cosign1.pub -k test-data/sigstore/cosign2.pub -a env=prod -a stable=true --request-path test-data/privileged-pod.json registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
     [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
     [ $(expr "$output" : '.*Policy successfully verified.*') -ne 0 ]
+    kwctl run -k test-data/sigstore/cosign1.pub -k test-data/sigstore/cosign3.pub -a env=prod -a stable=true --request-path test-data/privileged-pod.json registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    [ "$status" -eq 1 ]
+    [ $(expr "$output" : '.*The signature object didn'\''t have any layer signed with the given key.*') -ne 0 ]
 }


### PR DESCRIPTION
Before, the "verify a signed policy from an OCI registry" test was
calling `kwctl pull`, not `kwctl verify`. No harm done, as the same
codepath is executed since `kwctl pull` calls verify::verify().

Add case for `kwctl run` when verification is incorrect.