### PR TITLE
Small fixes to logging

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub fn build_cli() -> clap::App<'static, 'static> {
         .version(crate_version!())
         .author(crate_authors!())
         .about(crate_description!())
-        .arg(Arg::with_name("v").short("v").help("Increase verbosity"))
+        .arg(Arg::with_name("verbose").short("v").help("Increase verbosity"))
         .subcommand(
             SubCommand::with_name("policies")
                 .about("Lists all downloaded policies")

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ async fn main() -> Result<()> {
     let filter_layer = EnvFilter::new(level_filter)
         .add_directive("cranelift_codegen=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
         .add_directive("cranelift_wasm=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
+        .add_directive("hyper=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
         .add_directive("regalloc=off".parse().unwrap()); // this crate generates lots of tracing events we don't care about
     tracing_subscriber::registry()
         .with(filter_layer)

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3,7 +3,7 @@ use policy_fetcher::registry::config::DockerConfig;
 use policy_fetcher::sources::Sources;
 use policy_fetcher::verify::Verifier;
 use std::{collections::HashMap, fs};
-use tracing::info;
+use tracing::{debug, info};
 
 pub(crate) type VerificationAnnotations = HashMap<String, String>;
 
@@ -14,6 +14,7 @@ pub(crate) async fn verify(
     annotations: Option<&VerificationAnnotations>,
     key_file: &str,
 ) -> Result<String> {
+    debug!(policy = url, ?annotations, ?key_file, "Verifying policy");
     let verification_key = read_key_file(key_file)?;
     let mut verifier = Verifier::new(sources.cloned());
     let verified_manifest_digest = verifier


### PR DESCRIPTION
Some small fixes and improvements related with logging:

  * fix: restore the behaviour of the `-v` flag. It stopped working because of a typo on our side.
  * feat: silence the tracing events coming from one of our transient dependencies
  * feat: add some debug statements here and there

