### PR TITLE
(feat) Use SHA value in kwctl manifest lookup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -320,10 +320,10 @@ pub fn build_cli() -> clap::App<'static, 'static> {
                     .help("Output format")
                 )
                 .arg(
-                    Arg::with_name("uri")
+                    Arg::with_name("id")
                         .required(true)
                         .index(1)
-                        .help("Policy URI. Supported schemes: registry://, https://, file://")
+                        .help("Policy URI or SHA256. Supported schemes for URI: registry://, https://, file://")
                 )
         )
         .subcommand(

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -11,7 +11,6 @@ use syntect::parsing::SyntaxSet;
 pub(crate) fn inspect(id: &str, output: OutputType) -> Result<()> {
     let wasm_path: PathBuf; 
     let is_sha = crate::utils::is_sha(id);
-    println!("Is sha? {}", is_sha);
     if is_sha {
         wasm_path = crate::utils::wasm_path_from_sha(id)?;
     } else {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -5,12 +5,19 @@ use policy_evaluator::{
 };
 use prettytable::{format::FormatBuilder, Table};
 use pulldown_cmark::{Options, Parser};
-use std::convert::TryFrom;
+use std::{convert::TryFrom, path::PathBuf};
 use syntect::parsing::SyntaxSet;
 
-pub(crate) fn inspect(uri: &str, output: OutputType) -> Result<()> {
-    let uri = crate::utils::map_path_to_uri(uri)?;
-    let wasm_path = crate::utils::wasm_path(uri.as_str())?;
+pub(crate) fn inspect(id: &str, output: OutputType) -> Result<()> {
+    let wasm_path: PathBuf; 
+    let is_sha = crate::utils::is_sha(id);
+    println!("Is sha? {}", is_sha);
+    if is_sha {
+        wasm_path = crate::utils::wasm_path_from_sha(id)?;
+    } else {
+        let uri = crate::utils::map_path_to_uri(id)?;
+        wasm_path = crate::utils::wasm_path(uri.as_str())?;
+    }
     let printer = get_printer(output);
 
     let metadata = Metadata::from_path(&wasm_path)
@@ -19,7 +26,7 @@ pub(crate) fn inspect(uri: &str, output: OutputType) -> Result<()> {
         Some(metadata) => printer.print(&metadata),
         None => Err(anyhow!(
             "No Kubewarden metadata found inside of '{}'.\nPolicies can be annotated with the `kwctl annotate` command.",
-            uri
+            id
         )),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,7 +319,7 @@ async fn main() -> Result<()> {
         }
         Some("inspect") => {
             if let Some(matches) = matches.subcommand_matches("inspect") {
-                let uri = matches.value_of("uri").unwrap();
+                let uri = matches.value_of("id").unwrap();
                 let output = inspect::OutputType::try_from(matches.value_of("output"))?;
 
                 inspect::inspect(uri, output)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,14 +34,14 @@ pub(crate) fn map_path_to_uri(uri: &str) -> Result<String> {
 
 pub(crate) fn wasm_path_from_sha(sha: &str) -> Result<PathBuf> {
     let policies = Store::default().list()?;
-            let policy = policies.iter().find(
-                |policy|  {
-                    let mut policy_sha = policy.digest().unwrap();
-                    policy_sha.truncate(12);
-                    policy_sha == *sha
-                })
-                .ok_or_else(|| anyhow!("Cannot find policy by sha '{}' inside of the local store.\nTry executing `kwctl pull on the URI`", sha))?;
-            Ok(policy.local_path.clone())
+    let policy = policies.iter().find(
+        |policy|  {
+            let mut policy_sha = policy.digest().unwrap();
+            policy_sha.truncate(12);
+            policy_sha == *sha
+        })
+        .ok_or_else(|| anyhow!("Cannot find policy by sha '{}' inside of the local store.\nTry executing `kwctl pull on the URI`", sha))?;
+    Ok(policy.local_path.clone())
 }
 
 pub(crate) fn wasm_path(uri: &str) -> Result<PathBuf> {


### PR DESCRIPTION
Partially addresses #97 

Support looking up policies using the SHA value of the policy

Signed-off-by: Nitish Malhotra <nitish.malhotra@gmail.com>