### PR TITLE
enable more secure policy signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,7 +1929,7 @@ dependencies = [
  "lazy_static",
  "mdcat",
  "policy-evaluator",
- "policy-fetcher",
+ "policy-fetcher 0.4.0",
  "pretty-bytes",
  "prettytable-rs",
  "pulldown-cmark",
@@ -2329,6 +2329,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-distribution"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3c580ad67504493981fff06d790929ece7ce149f344f4d8e411808e5a50f62"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hyperx",
+ "jwt",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "unicase 1.4.2",
+ "url 1.7.2",
+ "www-authenticate",
+]
+
+[[package]]
+name = "oci-distribution"
+version = "0.8.1"
+source = "git+https://github.com/kubewarden/oci-distribution?branch=not-yet-merged-patches#241318a5b50372a7aeb2189aaf96d150e39d4be5"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hyperx",
+ "jwt",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "unicase 1.4.2",
+ "url 1.7.2",
+ "www-authenticate",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,8 +2622,8 @@ dependencies = [
  "kube",
  "kubewarden-policy-sdk",
  "lazy_static",
- "oci-distribution",
- "policy-fetcher",
+ "oci-distribution 0.8.0",
+ "policy-fetcher 0.3.0",
  "serde",
  "serde_json",
  "tokio",
@@ -2602,14 +2647,40 @@ dependencies = [
  "base64",
  "directories",
  "lazy_static",
- "oci-distribution",
+ "oci-distribution 0.8.0",
  "reqwest",
  "rustls 0.19.1",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
- "sigstore",
+ "sigstore 0.1.0 (git+https://github.com/kubewarden/sigstore-rs?branch=not-yet-merged-patches)",
+ "tracing",
+ "url 2.2.2",
+ "walkdir",
+]
+
+[[package]]
+name = "policy-fetcher"
+version = "0.4.0"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.4.0#404d5553f2bf11491b7becc772f82b20f3825a72"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "async-stream",
+ "async-trait",
+ "base64",
+ "directories",
+ "lazy_static",
+ "oci-distribution 0.8.1 (git+https://github.com/kubewarden/oci-distribution?branch=not-yet-merged-patches)",
+ "regex",
+ "reqwest",
+ "rustls 0.19.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "sigstore 0.1.0 (git+https://github.com/sigstore/sigstore-rs?rev=35fcc0f0a643c42989d301d6940add98f6ca6b6e)",
  "tracing",
  "url 2.2.2",
  "walkdir",
@@ -3309,7 +3380,26 @@ dependencies = [
  "async-trait",
  "base64",
  "ecdsa",
- "oci-distribution",
+ "oci-distribution 0.8.0",
+ "olpc-cjson",
+ "p256",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "x509-parser",
+]
+
+[[package]]
+name = "sigstore"
+version = "0.1.0"
+source = "git+https://github.com/sigstore/sigstore-rs?rev=35fcc0f0a643c42989d301d6940add98f6ca6b6e#35fcc0f0a643c42989d301d6940add98f6ca6b6e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "ecdsa",
+ "oci-distribution 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson",
  "p256",
  "serde",
@@ -4584,6 +4674,17 @@ dependencies = [
  "log",
  "thiserror",
  "wast 35.0.2",
+]
+
+[[package]]
+name = "www-authenticate"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02fd1970505d8d9842104b229ba0c6b6331c0897677d0fc0517ea657e77428d0"
+dependencies = [
+ "hyperx",
+ "unicase 1.4.2",
+ "url 1.7.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ kube = { version = "0.64.0", default-features = false, features = ["client", "ru
 lazy_static = "1.4.0"
 mdcat = "0.24"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.10" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.3.0" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.4.0" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.8", default-features = false }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,6 +177,15 @@ pub fn build_cli() -> clap::App<'static, 'static> {
                     .long("force")
                     .help("Push also a policy that is not annotated")
                 )
+                .arg(
+                    Arg::with_name("output")
+                    .long("output")
+                    .short("o")
+                    .takes_value(true)
+                    .possible_values(&["text", "json"])
+                    .default_value("text")
+                    .help("Output format")
+                )
                .arg(
                     Arg::with_name("policy")
                         .required(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ async fn main() -> Result<()> {
 
                 let force = matches.is_present("force");
 
-                push::push(
+                let immutable_ref = push::push(
                     wasm_path,
                     &uri,
                     docker_config.as_ref(),
@@ -197,8 +197,18 @@ async fn main() -> Result<()> {
                     force,
                 )
                 .await?;
+
+                match matches.value_of("output") {
+                    Some("json") => {
+                        let mut response: HashMap<&str, String> = HashMap::new();
+                        response.insert("immutable_ref", immutable_ref);
+                        serde_json::to_writer(std::io::stdout(), &response)?
+                    }
+                    _ => {
+                        println!("Policy successfully pushed: {}", immutable_ref);
+                    }
+                }
             };
-            println!("Policy successfully pushed");
             Ok(())
         }
         Some("rm") => {

--- a/src/push.rs
+++ b/src/push.rs
@@ -11,7 +11,7 @@ pub(crate) async fn push(
     docker_config: Option<&DockerConfig>,
     sources: Option<&Sources>,
     force: bool,
-) -> Result<()> {
+) -> Result<String> {
     match Metadata::from_path(&wasm_path)? {
         Some(_) => {}
         None => {


### PR DESCRIPTION
Change the `push` command to print the immutable reference to the policy image on the STDOUT.

The `push` sub-command has now a new optional parameter called `--output`. By default the immutable reference will be printed in a "human-friendly" mode, but the user can also print it as JSON, making it possible to parse it with scripts/automation.

The main reason for this change is to allow a more secure Sigstore signature process to our end users.

Signing an image by tag is not secure, because tags are mutable. There could be race conditions or even attacks that could lead the user to sign a different content from what he expected. 

Signing by immutable reference, on the other hand, is not affected by these issues.
