### PR TITLE
feat: Keyless verification for kwctl {verify,pull,run} 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1451,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1557,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -1995,7 +2026,7 @@ dependencies = [
  "lazy_static",
  "mdcat",
  "policy-evaluator",
- "policy-fetcher",
+ "policy-fetcher 0.4.3",
  "pretty-bytes",
  "prettytable-rs",
  "pulldown-cmark",
@@ -2439,6 +2470,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-distribution"
+version = "0.8.1"
+source = "git+https://github.com/krustlet/oci-distribution?rev=0f717968093a5415f428503d741dedf24ea97948#0f717968093a5415f428503d741dedf24ea97948"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hyperx",
+ "jwt",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "tokio",
+ "tracing",
+ "unicase 1.4.2",
+ "url 1.7.2",
+ "www-authenticate",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,6 +2648,24 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
+name = "path-absolutize"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b288298a7a3a7b42539e3181ba590d32f2d91237b0691ed5f103875c754b3bf5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfa72956f6be8524f7f7e2b07972dda393cb0008a6df4451f658b7e1bd1af80"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "path-slash"
@@ -2762,7 +2833,7 @@ dependencies = [
  "kubewarden-policy-sdk",
  "lazy_static",
  "oci-distribution 0.8.0",
- "policy-fetcher",
+ "policy-fetcher 0.4.3 (git+https://github.com/kubewarden/policy-fetcher?tag=v0.4.3)",
  "serde",
  "serde_json",
  "tokio",
@@ -2772,6 +2843,33 @@ dependencies = [
  "wapc",
  "wasmparser 0.82.0",
  "wasmtime-provider",
+]
+
+[[package]]
+name = "policy-fetcher"
+version = "0.4.3"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "async-stream",
+ "async-trait",
+ "base64",
+ "directories",
+ "lazy_static",
+ "oci-distribution 0.8.1 (git+https://github.com/krustlet/oci-distribution?rev=0f717968093a5415f428503d741dedf24ea97948)",
+ "path-slash",
+ "regex",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.2",
+ "sigstore 0.2.0",
+ "tracing",
+ "url 2.2.2",
+ "walkdir",
+ "wasmtime",
 ]
 
 [[package]]
@@ -3341,6 +3439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95455e7e29fada2052e72170af226fbe368a4ca33dee847875325d9fdb133858"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,6 +3558,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sigstore"
+version = "0.2.0"
+source = "git+https://github.com/sigstore/sigstore-rs?rev=5ae927a652db6076cb9d98b8e3fd8f5baadf3308#5ae927a652db6076cb9d98b8e3fd8f5baadf3308"
+dependencies = [
+ "async-trait",
+ "base64",
+ "oci-distribution 0.8.1 (git+https://github.com/krustlet/oci-distribution?rev=0f717968093a5415f428503d741dedf24ea97948)",
+ "olpc-cjson",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "sha2 0.10.2",
+ "thiserror",
+ "tokio",
+ "tough",
+ "tracing",
+ "url 2.2.2",
+ "x509-parser",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,6 +3602,28 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "snafu"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eba135d2c579aa65364522eb78590cdf703176ef71ad4c32b00f58f7afb2df5"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7fe9b0669ef117c5cabc5549638528f36771f058ff977d7689deb517833a75"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "socket2"
@@ -3808,6 +3959,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tough"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708125a84e70820bccc5fc11d7196664415be2b02b81ba6946e70e10803aa4da"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "globset",
+ "hex",
+ "log",
+ "olpc-cjson",
+ "path-absolutize",
+ "pem",
+ "percent-encoding 2.1.0",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "snafu",
+ "tempfile",
+ "untrusted",
+ "url 2.2.2",
+ "walkdir",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,6 +4233,7 @@ dependencies = [
  "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ kube = { version = "0.68.0", default-features = false, features = ["client", "ru
 lazy_static = "1.4.0"
 mdcat = "0.26.1"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.12" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.4.3" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", branch = "main" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.9.1", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ lint:
 test: fmt lint
 	cargo test --workspace
 
-.PHONY: cosign-initialize
-cosign-initialize:
+${HOME}/.sigstore/root/targets/fulcio_v1.crt.pem:
 	cosign initialize
 
 .PHONY: e2e-test
-e2e-test: cosign-initialize
+e2e-test: ${HOME}/.sigstore/root/targets/fulcio_v1.crt.pem
+e2e-test:
 	sh -c 'cd e2e-tests; bats --print-output-on-failure .'
 
 .PHONY: clean

--- a/e2e-tests/test-data/sigstore/verification-config-keyless.yml
+++ b/e2e-tests/test-data/sigstore/verification-config-keyless.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+
+allOf:
+  - kind: genericIssuer
+    issuer: https://token.actions.githubusercontent.com
+    subject:
+      urlPrefix: https://github.com/kubewarden

--- a/e2e-tests/test-data/sigstore/verification-config.yml
+++ b/e2e-tests/test-data/sigstore/verification-config.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+
+allOf:
+  - kind: pubKey
+    owner: pubkey1.pub
+    key: |
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQiTy5S+2JFvVlhUwWPLziM7iTM2j
+          byLgh2IjpNQN0Uio/9pZOTP/CsJmXoUNshfpTUHd3OxgHgz/6adtf2nBwQ==
+          -----END PUBLIC KEY-----
+    annotations:
+      env: prod
+      stable: "true"
+  - kind: pubKey
+    owner: pubkey2.pub
+    key: |
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEx0HuqSss8DUIIUg3I006b1EQjj3Q
+          igsTrvZ/Q3+h+81DkNJg4LzID1rz0UJFUcdzI5NqlFLSTDIQw0gVKOiK7g==
+          -----END PUBLIC KEY-----
+    annotations:
+      env: prod

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,12 @@ pub fn build_cli() -> Command<'static> {
                     .help("YAML file holding source information (https, registry insecure hosts, custom CA's...)")
                 )
                 .arg(
+                    Arg::new("verification-config-path")
+                    .long("verification-config-path")
+                    .takes_value(true)
+                    .help("YAML file holding verification config information (signatures, public keys...)")
+                )
+                .arg(
                     Arg::new("verification-key")
                     .short('k')
                     .long("verification-key")
@@ -117,13 +123,18 @@ pub fn build_cli() -> Command<'static> {
                     .help("YAML file holding source information (https, registry insecure hosts, custom CA's...)")
                 )
                 .arg(
+                    Arg::new("verification-config-path")
+                    .long("verification-config-path")
+                    .takes_value(true)
+                    .help("YAML file holding verification config information (signatures, public keys...)")
+                )
+                .arg(
                     Arg::new("verification-key")
                     .short('k')
                     .long("verification-key")
                     .multiple_occurrences(true)
                     .number_of_values(1)
                     .takes_value(true)
-                    .required(true)
                     .help("Path to key used to verify the policy. Can be repeated multiple times")
                 )
                 .arg(
@@ -221,6 +232,12 @@ pub fn build_cli() -> Command<'static> {
                     .long("sources-path")
                     .takes_value(true)
                     .help("YAML file holding source information (https, registry insecure hosts, custom CA's...)")
+                )
+                .arg(
+                    Arg::new("verification-config-path")
+                    .long("verification-config-path")
+                    .takes_value(true)
+                    .help("YAML file holding verification config information (signatures, public keys...)")
                 )
                 .arg(
                     Arg::new("request-path")

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,16 +21,19 @@ use std::{
 };
 use verify::VerificationAnnotations;
 
-use tracing::debug;
+use tracing::{debug, info};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
 use policy_evaluator::policy_evaluator::PolicyExecutionMode;
-use policy_fetcher::registry::config::{read_docker_config_json_file, DockerConfig};
 use policy_fetcher::registry::Registry;
 use policy_fetcher::sources::{read_sources_file, Sources};
 use policy_fetcher::store::DEFAULT_ROOT;
 use policy_fetcher::PullDestination;
+use policy_fetcher::{
+    registry::config::{read_docker_config_json_file, DockerConfig},
+    verify::config::{read_verification_file, LatestVerificationConfig, Signature},
+};
 
 use sigstore::SigstoreOpts;
 
@@ -50,6 +53,8 @@ mod run;
 mod sigstore;
 mod utils;
 mod verify;
+
+pub(crate) const KWCTL_VERIFICATION_CONFIG: &str = "verification-config.yml";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -422,9 +427,39 @@ fn remote_server_options(matches: &ArgMatches) -> Result<(Option<Sources>, Optio
     Ok((sources, docker_config))
 }
 
-fn verification_options(
+fn verification_options(matches: &ArgMatches) -> Result<Option<LatestVerificationConfig>> {
+    if let Some(verification_config) = build_verification_options_from_flags(matches)? {
+        // flags present, built configmap from them:
+        if matches.is_present("verification-config-path") {
+            return Err(anyhow!(
+                "verification-config-path cannot be used in conjunction with other verification flags"
+            ));
+        }
+        return Ok(Some(verification_config));
+    }
+    if let Some(verification_config_path) = matches.value_of("verification-config-path") {
+        // config flag present, read it:
+        return Ok(Some(read_verification_file(Path::new(
+            &verification_config_path,
+        ))?));
+    } else {
+        let verification_config_path = DEFAULT_ROOT.config_dir().join(KWCTL_VERIFICATION_CONFIG);
+        if Path::exists(&verification_config_path) {
+            // default config flag present, read it:
+            info!(path = ?verification_config_path, "Default verification config present, using it");
+            Ok(Some(read_verification_file(&verification_config_path)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+// Takes clap flags and builds a Some(LatestVerificationConfig) containing all
+// passed pub keys and annotations in LatestVerificationConfig.AllOf.
+// If no verification flags where used, it returns a None.
+fn build_verification_options_from_flags(
     matches: &ArgMatches,
-) -> Result<(Option<Vec<String>>, Option<VerificationAnnotations>)> {
+) -> Result<Option<LatestVerificationConfig>> {
     let key_files: Option<Vec<String>> = matches
         .values_of("verification-key")
         .map(|items| items.into_iter().map(|i| i.to_string()).collect());
@@ -448,13 +483,37 @@ fn verification_options(
             }
         };
 
+    if key_files.is_none() && annotations.is_none() {
+        // no verification flags were used, don't create a LatestVerificationConfig
+        return Ok(None);
+    }
+
     if key_files.is_none() && annotations.is_some() {
         return Err(anyhow!(
             "Intending to verify annotations, but no verification keys were passed"
         ));
     }
-
-    Ok((key_files, annotations))
+    let mut signatures: Vec<Signature> = Vec::new();
+    for key_path in key_files.iter().flatten() {
+        let sig = Signature::PubKey {
+            owner: None,
+            key: fs::read_to_string(key_path)
+                .map_err(|e| anyhow!("could not read file {}: {:?}", key_path, e))?
+                .to_string(),
+            annotations: annotations.clone(),
+        };
+        signatures.push(sig);
+    }
+    let signatures_all_of: Option<Vec<Signature>> = if signatures.is_empty() {
+        None
+    } else {
+        Some(signatures)
+    };
+    let verification_config = LatestVerificationConfig {
+        all_of: signatures_all_of,
+        any_of: None,
+    };
+    Ok(Some(verification_config))
 }
 
 fn sigstore_options(matches: &ArgMatches) -> Result<Option<SigstoreOpts>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
                 let mut verified_manifest_digest: Option<String> = None;
                 if verification_options.is_some() {
                     let sigstore_options = sigstore_options(matches)?
-                        .ok_or(anyhow!("could not retrieve sigstore options"))?;
+                        .ok_or_else(|| anyhow!("could not retrieve sigstore options"))?;
                     // verify policy prior to pulling if keys listed, and keep the
                     // verified manifest digest:
                     verified_manifest_digest = Some(
@@ -116,7 +116,7 @@ async fn main() -> Result<()> {
 
                 if verification_options.is_some() {
                     let sigstore_options = sigstore_options(matches)?
-                        .ok_or(anyhow!("could not retrieve sigstore options"))?;
+                        .ok_or_else(|| anyhow!("could not retrieve sigstore options"))?;
                     verify::verify_local_checksum(
                         &policy,
                         docker_config.as_ref(),
@@ -134,9 +134,9 @@ async fn main() -> Result<()> {
                 let uri = matches.value_of("uri").unwrap();
                 let (sources, docker_config) = remote_server_options(matches)?;
                 let verification_options = verification_options(matches)?
-                    .ok_or(anyhow!("could not retrieve verification options"))?;
+                    .ok_or_else(|| anyhow!("could not retrieve sigstore options"))?;
                 let sigstore_options = sigstore_options(matches)?
-                    .ok_or(anyhow!("could not retrieve sigstore options"))?;
+                    .ok_or_else(|| anyhow!("could not retrieve sigstore options"))?;
                 verify::verify(
                     uri,
                     docker_config.as_ref(),
@@ -263,7 +263,7 @@ async fn main() -> Result<()> {
                             verification_options.as_ref().unwrap(),
                             &sigstore_options
                                 .clone()
-                                .ok_or(anyhow!("could not retrieve sigstore options"))?,
+                                .ok_or_else(|| anyhow!("could not retrieve sigstore options"))?,
                         )
                         .await
                         .map_err(|e| anyhow!("Policy {} cannot be validated: {:?}", uri, e))?,
@@ -278,7 +278,7 @@ async fn main() -> Result<()> {
                     &request,
                     settings,
                     &verified_manifest_digest,
-                    sigstore_options.clone().as_ref(),
+                    sigstore_options.as_ref(),
                 )
                 .await?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<()> {
                             &sigstore_options,
                         )
                         .await
-                        .map_err(|e| anyhow!("Policy {} cannot be validated: {:?}", uri, e))?,
+                        .map_err(|e| anyhow!("Policy {} cannot be validated\n{:?}", uri, e))?,
                     );
                 }
 
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
                     &sigstore_options,
                 )
                 .await
-                .map_err(|e| anyhow!("Policy {} cannot be validated: {:?}", uri, e))?;
+                .map_err(|e| anyhow!("Policy {} cannot be validated\n{:?}", uri, e))?;
             };
             Ok(())
         }
@@ -266,7 +266,7 @@ async fn main() -> Result<()> {
                                 .ok_or_else(|| anyhow!("could not retrieve sigstore options"))?,
                         )
                         .await
-                        .map_err(|e| anyhow!("Policy {} cannot be validated: {:?}", uri, e))?,
+                        .map_err(|e| anyhow!("Policy {} cannot be validated\n{:?}", uri, e))?,
                     );
                 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -249,7 +249,7 @@ mod tests {
             metadata,
             user_execution_mode,
             backend_detector,
-            &PathBuf::from("irrelevant.wasm").to_path_buf(),
+            &PathBuf::from("irrelevant.wasm"),
         );
         assert!(mode.is_err());
     }
@@ -271,7 +271,7 @@ mod tests {
             metadata,
             user_execution_mode,
             backend_detector,
-            &PathBuf::from("irrelevant.wasm").to_path_buf(),
+            &PathBuf::from("irrelevant.wasm"),
         );
         assert!(mode.is_ok());
         assert_eq!(PolicyExecutionMode::Opa, mode.unwrap());
@@ -282,7 +282,7 @@ mod tests {
         let user_execution_mode = None;
         let expected_execution_mode = PolicyExecutionMode::Opa;
         let metadata = Some(Metadata {
-            execution_mode: expected_execution_mode.clone(),
+            execution_mode: expected_execution_mode,
             ..Default::default()
         });
 
@@ -295,7 +295,7 @@ mod tests {
             metadata,
             user_execution_mode,
             backend_detector,
-            &PathBuf::from("irrelevant.wasm").to_path_buf(),
+            &PathBuf::from("irrelevant.wasm"),
         );
         assert!(mode.is_ok());
         assert_eq!(expected_execution_mode, mode.unwrap());

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -55,7 +55,3 @@ pub(crate) async fn verify_local_checksum(
     info!("Local checksum successfully verified");
     Ok(())
 }
-
-fn read_key_file(path: &str) -> Result<String> {
-    fs::read_to_string(path).map_err(|e| anyhow!("could not read file {}: {:?}", path, e))
-}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/policy-server/issues/142

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Implement Sigstore keyless verification for`kwctl {verify,pull,run}`.
Now, accept new `--verification-config-path` that contains the config from [the Sigstore verification RFC](https://github.com/kubewarden/kubewarden-controller/blob/main/rfc/0003-policy-signing.md).
Previous flags are still supported: they get translated into a VerificationSettings config, to be used with the verification.

## Test

Run `make test e2e-test`.
Added e2e-tests that exercise `--verification-config-path`. 

## Additional Information

Depends on https://github.com/kubewarden/policy-fetcher/pull/55.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

Create verification-config:
Provide better info on missing signatures: opened https://github.com/kubewarden/policy-fetcher/issues/57
Provide default verification-config: opened https://github.com/kubewarden/kwctl/issues/170
