### PR TITLE
feat: sigstore - download keys and certs from TUF repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
+checksum = "71acf5509fc522cce1b100ac0121c635129bfd4d91cdf036bcc9b9935f97ccf5"
 
 [[package]]
 name = "bincode"
@@ -368,7 +368,7 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 [[package]]
 name = "burrego"
 version = "0.1.2"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.12#0419eb5cc47d242818377d07e1389bc7ac69b1b4"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.14#bc9fa9c060e2c3bdac155223ce4a3c165846402b"
 dependencies = [
  "anyhow",
  "base64",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "constant_time_eq"
@@ -802,14 +802,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
- "rand_core",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -916,11 +914,13 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
+ "crypto-bigint",
+ "pem-rfc7468",
 ]
 
 [[package]]
@@ -1041,38 +1041,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
-name = "ecdsa"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
-dependencies = [
- "der",
- "elliptic-curve",
- "hmac",
- "signature",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
-dependencies = [
- "crypto-bigint",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "encode_unicode"
@@ -1198,16 +1170,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ff"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
-dependencies = [
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -1473,17 +1435,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "group"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -1924,6 +1875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
 name = "kube"
 version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,7 +1983,7 @@ dependencies = [
  "lazy_static",
  "mdcat",
  "policy-evaluator",
- "policy-fetcher 0.4.3 (git+https://github.com/kubewarden/policy-fetcher?branch=main)",
+ "policy-fetcher",
  "pretty-bytes",
  "prettytable-rs",
  "pulldown-cmark",
@@ -2057,6 +2014,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -2078,9 +2038,15 @@ checksum = "7efd1d698db0759e6ef11a7cd44407407399a910c774dd804c64c032da7826ff"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+
+[[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "line-wrap"
@@ -2157,6 +2123,15 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "md-5"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+dependencies = [
+ "digest 0.10.3",
+]
 
 [[package]]
 name = "mdcat"
@@ -2313,6 +2288,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2406,72 +2400,6 @@ dependencies = [
 
 [[package]]
 name = "oci-distribution"
-version = "0.8.0"
-source = "git+https://github.com/krustlet/oci-distribution?rev=96f19570e7#96f19570e7f9dd56ed9cce8c9e8095e7c2d7753b"
-dependencies = [
- "anyhow",
- "futures-util",
- "hyperx",
- "jwt",
- "lazy_static",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tokio",
- "tracing",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "oci-distribution"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3c580ad67504493981fff06d790929ece7ce149f344f4d8e411808e5a50f62"
-dependencies = [
- "anyhow",
- "futures-util",
- "hyperx",
- "jwt",
- "lazy_static",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tokio",
- "tracing",
- "unicase 1.4.2",
- "url 1.7.2",
- "www-authenticate",
-]
-
-[[package]]
-name = "oci-distribution"
-version = "0.8.1"
-source = "git+https://github.com/kubewarden/oci-distribution?branch=not-yet-merged-patches#241318a5b50372a7aeb2189aaf96d150e39d4be5"
-dependencies = [
- "anyhow",
- "futures-util",
- "hyperx",
- "jwt",
- "lazy_static",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tokio",
- "tracing",
- "unicase 1.4.2",
- "url 1.7.2",
- "www-authenticate",
-]
-
-[[package]]
-name = "oci-distribution"
 version = "0.8.1"
 source = "git+https://github.com/krustlet/oci-distribution?rev=0f717968093a5415f428503d741dedf24ea97948#0f717968093a5415f428503d741dedf24ea97948"
 dependencies = [
@@ -2490,6 +2418,15 @@ dependencies = [
  "unicase 1.4.2",
  "url 1.7.2",
  "www-authenticate",
+]
+
+[[package]]
+name = "oid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2568,17 +2505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "p256"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2 0.9.9",
 ]
 
 [[package]]
@@ -2685,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
 dependencies = [
  "base64ct",
 ]
@@ -2744,6 +2670,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "picky"
+version = "7.0.0-rc.2"
+source = "git+https://github.com/Devolutions/picky-rs.git?tag=picky-7.0.0-rc.2#912af2ea93051e53aadf97a1dc8bb5e43dee51ee"
+dependencies = [
+ "base64",
+ "digest 0.10.3",
+ "md-5",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
+ "picky-asn1-x509",
+ "rand",
+ "ring",
+ "rsa",
+ "serde",
+ "sha-1",
+ "sha2 0.10.2",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "picky-asn1"
+version = "0.5.0"
+source = "git+https://github.com/Devolutions/picky-rs.git?tag=picky-7.0.0-rc.2#912af2ea93051e53aadf97a1dc8bb5e43dee51ee"
+dependencies = [
+ "oid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-der"
+version = "0.3.0"
+source = "git+https://github.com/Devolutions/picky-rs.git?tag=picky-7.0.0-rc.2#912af2ea93051e53aadf97a1dc8bb5e43dee51ee"
+dependencies = [
+ "picky-asn1",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.7.0"
+source = "git+https://github.com/Devolutions/picky-rs.git?tag=picky-7.0.0-rc.2#912af2ea93051e53aadf97a1dc8bb5e43dee51ee"
+dependencies = [
+ "base64",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
+ "serde",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,13 +2758,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.7.6"
+name = "pkcs1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
 dependencies = [
  "der",
- "pem-rfc7468",
+ "pkcs8",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
  "spki",
  "zeroize",
 ]
@@ -2821,8 +2813,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.2.12"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.12#0419eb5cc47d242818377d07e1389bc7ac69b1b4"
+version = "0.2.14"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.14#bc9fa9c060e2c3bdac155223ce4a3c165846402b"
 dependencies = [
  "anyhow",
  "base64",
@@ -2833,8 +2825,7 @@ dependencies = [
  "kube",
  "kubewarden-policy-sdk",
  "lazy_static",
- "oci-distribution 0.8.0",
- "policy-fetcher 0.4.3 (git+https://github.com/kubewarden/policy-fetcher?tag=v0.4.3)",
+ "policy-fetcher",
  "serde",
  "serde_json",
  "tokio",
@@ -2848,8 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.4.3"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.4.3#3a205e0ace6b101ed551453cd1ef27f356d46eb9"
+version = "0.5.0"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.5.0#6fe85ba4f7a64e60171aead5511cea34d78d261d"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2858,7 +2849,7 @@ dependencies = [
  "base64",
  "directories",
  "lazy_static",
- "oci-distribution 0.8.1 (git+https://github.com/kubewarden/oci-distribution?branch=not-yet-merged-patches)",
+ "oci-distribution",
  "path-slash",
  "regex",
  "reqwest",
@@ -2867,35 +2858,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.2",
- "sigstore 0.1.0",
- "tracing",
- "url 2.2.2",
- "walkdir",
- "wasmtime",
-]
-
-[[package]]
-name = "policy-fetcher"
-version = "0.4.3"
-source = "git+https://github.com/kubewarden/policy-fetcher?branch=main#47f4b5dfb273d32e720c42f299ce1b7708892270"
-dependencies = [
- "anyhow",
- "async-std",
- "async-stream",
- "async-trait",
- "base64",
- "directories",
- "lazy_static",
- "oci-distribution 0.8.1 (git+https://github.com/krustlet/oci-distribution?rev=0f717968093a5415f428503d741dedf24ea97948)",
- "path-slash",
- "regex",
- "reqwest",
- "rustls",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2 0.10.2",
- "sigstore 0.2.0",
+ "sigstore",
  "tracing",
  "url 2.2.2",
  "walkdir",
@@ -3210,6 +3173,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.6.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6c133a3224dee86b9097119aabaca6399a1878d3102d55d4448b4b96cbe8f0"
+dependencies = [
+ "byteorder",
+ "digest 0.10.3",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,6 +3399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,6 +3464,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3494,6 +3496,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+dependencies = [
+ "digest 0.10.3",
+ "keccak",
 ]
 
 [[package]]
@@ -3530,44 +3542,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
-dependencies = [
- "digest 0.9.0",
- "rand_core",
-]
-
-[[package]]
-name = "sigstore"
-version = "0.1.0"
-source = "git+https://github.com/sigstore/sigstore-rs?rev=35fcc0f0a643c42989d301d6940add98f6ca6b6e#35fcc0f0a643c42989d301d6940add98f6ca6b6e"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64",
- "ecdsa",
- "oci-distribution 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "olpc-cjson",
- "p256",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "x509-parser",
-]
-
-[[package]]
 name = "sigstore"
 version = "0.2.0"
-source = "git+https://github.com/sigstore/sigstore-rs?rev=5ae927a652db6076cb9d98b8e3fd8f5baadf3308#5ae927a652db6076cb9d98b8e3fd8f5baadf3308"
+source = "git+https://github.com/sigstore/sigstore-rs?rev=3954129ff0fc91beb8b8a6568ecb09e8c2d19392#3954129ff0fc91beb8b8a6568ecb09e8c2d19392"
 dependencies = [
  "async-trait",
  "base64",
- "oci-distribution 0.8.1 (git+https://github.com/krustlet/oci-distribution?rev=0f717968093a5415f428503d741dedf24ea97948)",
+ "lazy_static",
+ "oci-distribution",
  "olpc-cjson",
  "pem",
+ "picky",
+ "regex",
  "ring",
  "serde",
  "serde_json",
@@ -3653,10 +3639,11 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
+ "base64ct",
  "der",
 ]
 
@@ -3680,9 +3667,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "1e59d925cf59d8151f25a3bedf97c9c157597c9df7324d32d68991cc399ed08b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4991,9 +4978,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22
 kube = { version = "0.68.0", default-features = false, features = ["client", "rustls-tls"] }
 lazy_static = "1.4.0"
 mdcat = "0.26.1"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.12" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", branch = "main" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.14" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.5.0" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.9.1", default-features = false }

--- a/e2e-tests/secure_supply_chain_tests.bats
+++ b/e2e-tests/secure_supply_chain_tests.bats
@@ -1,13 +1,15 @@
 #!/usr/bin/env bats
 
+FULCIO_AND_REKORD_DATA_DIR=$(readlink -f ~/.config/kubewarden/fulcio_and_rekor_data)
+
 setup() {
     rm -rf ~/.cache/kubewarden
+    rm -rf ${FULCIO_AND_REKORD_DATA_DIR}
 }
 
 kwctl() {
     run cargo -q run -- "$@"
 }
-
 
 @test "[Secure supply chain  tests] \"verify\" command should have some minimum command line flags" {
     kwctl verify --help
@@ -55,71 +57,135 @@ kwctl() {
     kwctl verify -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*Intending to verify annotations, but no verification keys, OIDC issuer or GitHub owner were passed.*') -ne 0 ]
+
     kwctl verify -k test-data/sigstore/cosign1.pub -k unexistent-path-to-key.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*No such file or directory.*') -ne 0 ]
+
     kwctl verify -k test-data/sigstore/cosign1.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
     [ $(expr "$output" : '.*Policy successfully verified.*') -ne 0 ]
+
     kwctl verify -k test-data/sigstore/cosign1.pub -k test-data/sigstore/cosign2.pub -a env=prod registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
     [ $(expr "$output" : '.*Policy successfully verified.*') -ne 0 ]
+
     kwctl verify -k test-data/sigstore/cosign3.pub registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*Image verification failed: missing signatures.*') -ne 0 ]
+
     kwctl verify -k test-data/sigstore/cosign2.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*Image verification failed: missing signatures.*') -ne 0 ]
-    kwctl verify --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
-        --verification-config-path=test-data/sigstore/verification-config.yml \
-        registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+
+    kwctl verify \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio.crt.pem \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
+      --rekor-public-key-path ~/.sigstore/root/targets/rekor.pub \
+      --verification-config-path=test-data/sigstore/verification-config.yml \
+      registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
-    kwctl verify --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
-        --verification-config-path=test-data/sigstore/verification-config.yml \
-        registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
+
+    kwctl verify \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio.crt.pem \
+      --verification-config-path=test-data/sigstore/verification-config.yml \
+      registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    [ "$status" -eq 1 ]
+    [ $(expr "$output" : '.*both a fulcio certificate and a rekor public key are required.*') -ne 0 ]
+
+    kwctl verify \
+      --rekor-public-key-path ~/.sigstore/root/targets/rekor.pub \
+      --verification-config-path=test-data/sigstore/verification-config.yml \
+      registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    [ "$status" -eq 1 ]
+    [ $(expr "$output" : '.*both a fulcio certificate and a rekor public key are required.*') -ne 0 ]
+
+    kwctl verify \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio.crt.pem \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
+      --rekor-public-key-path ~/.sigstore/root/targets/rekor.pub \
+      --verification-config-path=test-data/sigstore/verification-config.yml \
+      registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*Image verification failed: missing signatures.*') -ne 0 ]
-    kwctl verify --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
-        --verification-config-path=test-data/sigstore/verification-config-keyless.yml \
-        registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
+
+    kwctl verify \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio.crt.pem \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
+      --rekor-public-key-path ~/.sigstore/root/targets/rekor.pub \
+      --verification-config-path=test-data/sigstore/verification-config-keyless.yml \
+      registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
     [ "$status" -eq 0 ]
+
+    # Test TUF integration
+    rm -rf ${FULCIO_AND_REKORD_DATA_DIR}
+    kwctl verify \
+      --verification-config-path=test-data/sigstore/verification-config-keyless.yml \
+      registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
+    [ "$status" -eq 0 ]
+    [ -f ${FULCIO_AND_REKORD_DATA_DIR}/fulcio.crt.pem ]
+    [ -f ${FULCIO_AND_REKORD_DATA_DIR}/fulcio_v1.crt.pem ]
+    [ -f ${FULCIO_AND_REKORD_DATA_DIR}/rekor.pub ]
 }
 
 @test "[Secure supply chain  tests] pull a signed policy from an OCI registry" {
     kwctl pull -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*Intending to verify annotations, but no verification keys, OIDC issuer or GitHub owner were passed.*') -ne 0 ]
+
     kwctl pull -k test-data/sigstore/cosign1.pub -a env=prod -a stable=true registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
     [ $(expr "$output" : '.*Policy successfully verified.*') -ne 0 ]
     [ $(expr "$output" : '.*Local checksum successfully verified.*') -ne 0 ]
-    kwctl verify --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
-        --verification-config-path=test-data/sigstore/verification-config.yml \
-        registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+
+    kwctl verify \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio.crt.pem \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
+      --rekor-public-key-path ~/.sigstore/root/targets/rekor.pub \
+      --verification-config-path=test-data/sigstore/verification-config.yml \
+      registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
-    kwctl pull --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
-        --verification-config-path=test-data/sigstore/verification-config.yml \
-        registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
+
+    kwctl pull \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio.crt.pem \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
+      --rekor-public-key-path ~/.sigstore/root/targets/rekor.pub \
+      --verification-config-path=test-data/sigstore/verification-config.yml \
+      registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*Image verification failed: missing signatures.*') -ne 0 ]
 }
 
 @test "[Secure supply chain  tests] execute a signed policy from an OCI registry" {
-    kwctl run -k test-data/sigstore/cosign1.pub -k test-data/sigstore/cosign2.pub -a env=prod --request-path test-data/privileged-pod.json registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    kwctl run \
+      -k test-data/sigstore/cosign1.pub \
+      -k test-data/sigstore/cosign2.pub \
+      -a env=prod \
+      --request-path test-data/privileged-pod.json \
+      registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
     [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
     [ $(expr "$output" : '.*Policy successfully verified.*') -ne 0 ]
+
     kwctl run -k test-data/sigstore/cosign1.pub -k test-data/sigstore/cosign3.pub -a env=prod -a stable=true --request-path test-data/privileged-pod.json registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*Image verification failed: missing signatures.*') -ne 0 ]
-    kwctl run --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
-        --verification-config-path=test-data/sigstore/verification-config.yml \
-        --request-path test-data/privileged-pod.json registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+
+    kwctl run \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio.crt.pem \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
+      --rekor-public-key-path ~/.sigstore/root/targets/rekor.pub \
+      --verification-config-path=test-data/sigstore/verification-config.yml \
+      --request-path test-data/privileged-pod.json registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     [ "$status" -eq 0 ]
-    kwctl run --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
-        --verification-config-path=test-data/sigstore/verification-config.yml \
-        --request-path test-data/privileged-pod.json \
-        registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
+
+    kwctl run \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio.crt.pem \
+      --fulcio-cert-path ~/.sigstore/root/targets/fulcio_v1.crt.pem \
+      --rekor-public-key-path ~/.sigstore/root/targets/rekor.pub \
+      --verification-config-path=test-data/sigstore/verification-config.yml \
+      --request-path test-data/privileged-pod.json \
+      registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
     [ "$status" -eq 1 ]
     [ $(expr "$output" : '.*Image verification failed: missing signatures.*') -ne 0 ]
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,6 @@ use clap::{crate_authors, crate_description, crate_name, crate_version, Arg, Com
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use policy_evaluator::burrego::opa::builtins as opa_builtins;
-use std::path::PathBuf;
 
 lazy_static! {
     static ref VERSION_AND_BUILTINS: String = {
@@ -18,18 +17,6 @@ lazy_static! {
             builtins,
         )
     };
-    static ref SIGSTORE_TARGETS_PATH: PathBuf = {
-        directories::BaseDirs::new()
-            .unwrap_or_else(|| panic!("not possible to build base dirs"))
-            .home_dir()
-            .join(".sigstore")
-            .join("root")
-            .join("targets")
-    };
-    pub(crate) static ref SIGSTORE_FULCIO_CERT_PATH: PathBuf =
-        SIGSTORE_TARGETS_PATH.join("fulcio.crt.pem");
-    pub(crate) static ref SIGSTORE_REKOR_PUBLIC_KEY_PATH: PathBuf =
-        SIGSTORE_TARGETS_PATH.join("rekor.pub");
 }
 
 pub fn build_cli() -> Command<'static> {
@@ -75,8 +62,10 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("fulcio-cert-path")
                     .long("fulcio-cert-path")
+                    .multiple_occurrences(true)
+                    .number_of_values(1)
                     .takes_value(true)
-                    .help("Path to the Fulcio certificate")
+                    .help("Path to the Fulcio certificate. Can be repeated multiple times")
                 )
                 .arg(
                     Arg::new("rekor-public-key-path")
@@ -172,8 +161,10 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("fulcio-cert-path")
                     .long("fulcio-cert-path")
+                    .multiple_occurrences(true)
+                    .number_of_values(1)
                     .takes_value(true)
-                    .help("Path to the Fulcio certificate")
+                    .help("Path to the Fulcio certificate. Can be repeated multiple times")
                 )
                 .arg(
                     Arg::new("rekor-public-key-path")
@@ -336,8 +327,10 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("fulcio-cert-path")
                     .long("fulcio-cert-path")
+                    .multiple_occurrences(true)
+                    .number_of_values(1)
                     .takes_value(true)
-                    .help("Path to the Fulcio certificate")
+                    .help("Path to the Fulcio certificate. Can be repeated multiple times")
                 )
                 .arg(
                     Arg::new("rekor-public-key-path")

--- a/src/run.rs
+++ b/src/run.rs
@@ -7,10 +7,12 @@ use policy_evaluator::{
     policy_evaluator_builder::PolicyEvaluatorBuilder,
     policy_metadata::Metadata,
 };
-use policy_fetcher::{registry::config::DockerConfig, sources::Sources};
+use policy_fetcher::{
+    registry::config::DockerConfig, sources::Sources, verify::FulcioAndRekorData,
+};
 use std::path::Path;
 
-use crate::{backend::BackendDetector, pull, sigstore::SigstoreOpts, verify};
+use crate::{backend::BackendDetector, pull, verify};
 
 // TODO(ereslibre): arguments to be refactored, and allow to be removed.
 #[allow(clippy::too_many_arguments)]
@@ -22,7 +24,7 @@ pub(crate) async fn pull_and_run(
     request: &str,
     settings: Option<String>,
     verified_manifest_digest: &Option<String>,
-    sigstore_opts: Option<&SigstoreOpts>,
+    fulcio_and_rekor_data: &FulcioAndRekorData,
 ) -> Result<()> {
     let uri = crate::utils::map_path_to_uri(uri)?;
 
@@ -41,7 +43,7 @@ pub(crate) async fn pull_and_run(
             docker_config,
             sources,
             digest,
-            sigstore_opts.ok_or_else(|| anyhow!("could not retrieve sigstore options"))?,
+            fulcio_and_rekor_data,
         )
         .await?
     }

--- a/src/sigstore.rs
+++ b/src/sigstore.rs
@@ -1,5 +1,0 @@
-#[derive(Clone)]
-pub(crate) struct SigstoreOpts {
-    pub fulcio_cert: Vec<u8>,
-    pub rekor_public_key: String,
-}


### PR DESCRIPTION
Leverage the TUF integration offered by sigstore-rs to download Fulcio and Rekor data from the official TUF repository of sigstore.

Users are still allowed to provide custom Fulcio and Rekor data by loading it from the local filesystem.

This fixes https://github.com/kubewarden/kwctl/issues/177

Note well: this builds on top of https://github.com/kubewarden/policy-fetcher/pull/67 - I'll rebase the code once it gets merged
