### PR TITLE
Update to latest policy-fetcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 [[package]]
 name = "burrego"
 version = "0.1.2"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.14#bc9fa9c060e2c3bdac155223ce4a3c165846402b"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.15#a9e9123bf16cd2308a4d20aff13c8446f96d0c96"
 dependencies = [
  "anyhow",
  "base64",
@@ -2813,8 +2813,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.2.14"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.14#bc9fa9c060e2c3bdac155223ce4a3c165846402b"
+version = "0.2.15"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.15#a9e9123bf16cd2308a4d20aff13c8446f96d0c96"
 dependencies = [
  "anyhow",
  "base64",
@@ -2839,8 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.5.0"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.5.0#6fe85ba4f7a64e60171aead5511cea34d78d261d"
+version = "0.6.0"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.6.0#b53e7f9ced222a3ede6c8368645f5d57859d4921"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22
 kube = { version = "0.68.0", default-features = false, features = ["client", "rustls-tls"] }
 lazy_static = "1.4.0"
 mdcat = "0.26.1"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.14" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.5.0" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.15" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.6.0" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.9.1", default-features = false }

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -8,5 +8,5 @@ pub(crate) async fn pull(
     sources: Option<&Sources>,
     destination: PullDestination,
 ) -> Result<Policy> {
-    fetch_policy(uri, destination, docker_config.cloned(), sources).await
+    fetch_policy(uri, destination, docker_config, sources).await
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -18,7 +18,7 @@ pub(crate) async fn verify(
     debug!(policy = url, "Verifying policy");
     let mut verifier = Verifier::new(sources.cloned(), fulcio_and_rekor_data)?;
     let verified_manifest_digest = verifier
-        .verify(url, docker_config.cloned(), verification_config.clone())
+        .verify(url, docker_config, verification_config)
         .await?;
 
     info!("Policy successfully verified");
@@ -34,7 +34,7 @@ pub(crate) async fn verify_local_checksum(
 ) -> Result<()> {
     let mut verifier = Verifier::new(sources.cloned(), fulcio_and_rekor_data)?;
     verifier
-        .verify_local_file_checksum(policy, docker_config.cloned(), verified_manifest_digest)
+        .verify_local_file_checksum(policy, docker_config, verified_manifest_digest)
         .await?;
 
     info!("Local checksum successfully verified");


### PR DESCRIPTION
> **Note well:** this PR depends on https://github.com/kubewarden/policy-fetcher/pull/69 - It's currently in draft mode, but it can be reviewed.
> Once the PR is merged, and a new version of policy-fetcher is tagged, I'll update the PR to consume the freshly tagged version.


Latest policy-fetcher changed some of its public API. This commit fixes the compilation.
