### PR TITLE
Enable usage of wasmtime cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 [[package]]
 name = "burrego"
 version = "0.1.3"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.3.6#0e588d5f811fa73a77fc166297559f54df0a093d"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.3.7#fd60b4e9c53c3f3298e765ca7e3e09592af61c2e"
 dependencies = [
  "anyhow",
  "base64",
@@ -2998,8 +2998,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.3.6"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.3.6#0e588d5f811fa73a77fc166297559f54df0a093d"
+version = "0.3.7"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.3.7#fd60b4e9c53c3f3298e765ca7e3e09592af61c2e"
 dependencies = [
  "anyhow",
  "base64",
@@ -3021,6 +3021,7 @@ dependencies = [
  "validator",
  "wapc",
  "wasmparser 0.85.0",
+ "wasmtime",
  "wasmtime-provider",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.10.3"
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_24"] }
 lazy_static = "1.4.0"
 mdcat = "0.27.1"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.3.6" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.3.7" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.9.1", default-features = false }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,6 +389,11 @@ pub fn build_cli() -> Command<'static> {
                     .help("The runtime to use to execute this policy")
                 )
                 .arg(
+                    Arg::new("disable-wasmtime-cache")
+                    .long("disable-wasmtime-cache")
+                    .help("Turn off usage of wasmtime cache")
+                )
+                .arg(
                     Arg::new("uri")
                         .required(true)
                         .index(1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,8 @@ async fn main() -> Result<()> {
                     );
                 }
 
+                let enable_wasmtime_cache = !matches.is_present("disable-wasmtime-cache");
+
                 run::pull_and_run(
                     uri,
                     execution_mode,
@@ -291,6 +293,7 @@ async fn main() -> Result<()> {
                     settings,
                     &verified_manifest_digest,
                     &fulcio_and_rekor_data,
+                    enable_wasmtime_cache,
                 )
                 .await?;
             }


### PR DESCRIPTION
> **Warning:** this PR depends on https://github.com/kubewarden/policy-evaluator/pull/137

Wasmtime performs a series of operations when a Wasm module is instantiated (see [the official docs](https://docs.wasmtime.dev/contributing-architecture.html?highlight=jit#instantiating-a-module)).
These operations can take a significant amount of time with big WebAssembly modules (like the ones produced by TinyGo when Kubernetes native types are used), which is a big problem for kwctl.

Wasmtime has a feature called "cache", which saves an optimized version of the WebAssembly module to disk, so that it can be later reused to quickly start new instances of it.

The `wasmtime` cli tool is using this feature by default, hence it's considered stable.

This change will make `kwctl` enable the wasmtime cache feature by default. This will remove the cold-start penalty when kwctl runs a WebAssembly module has already been executed once.

## A concrete example.

A Kubewarden policy written with TinyGo, which makes use of Kubernetes object, takes around 21 seconds to start on my machine. When the cache is enabled the next runs take around ~ 1.2 seconds.

This can be really helpful when operators are testing different settings of the policy, or when developers run end to end tests.
