### PR TITLE
Suppress wasmtime cache warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,8 @@ async fn main() -> Result<()> {
         .add_directive("cranelift_codegen=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
         .add_directive("cranelift_wasm=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
         .add_directive("hyper=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
-        .add_directive("regalloc=off".parse().unwrap()); // this crate generates lots of tracing events we don't care about
+        .add_directive("regalloc=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
+        .add_directive("wasmtime_cache=off".parse().unwrap()); // wasmtime_cache messages are not critical and just confuse users
     tracing_subscriber::registry()
         .with(filter_layer)
         .with(fmt::layer().with_writer(std::io::stderr))


### PR DESCRIPTION
The warning messages are not critical, but they confuse the users.

Moreover, they pollute the stdout, leading to end to end test breakage.

Fixes https://github.com/kubewarden/kwctl/issues/240
