### PR TITLE
Consume policy-evaluator 0.4.4, and bump version to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 [[package]]
 name = "burrego"
 version = "0.1.3"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.3#ada02c231b14c51a43437531f38080a94b5cfc02"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.4#e47bda8e9667e767d7c1fa35d7401f6a6d62e96e"
 dependencies = [
  "anyhow",
  "base64",
@@ -2091,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbeb0918c65e2beed24f7eadf69835b545045d1f1aabcb6a95e3282ea2e33ef"
+checksum = "bb4f07471a46151c3272d2ed0e3e62ecbae9b75ff374476c9468b54cd6b20a10"
 dependencies = [
  "anyhow",
  "k8s-openapi",
@@ -3019,8 +3019,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.4.3"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.3#ada02c231b14c51a43437531f38080a94b5cfc02"
+version = "0.4.4"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.4#e47bda8e9667e767d7c1fa35d7401f6a6d62e96e"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.10.3"
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_24"] }
 lazy_static = "1.4.0"
 mdcat = "0.27.1"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.3" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.4" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.9.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.0.1"
+version = "1.1.0"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]


### PR DESCRIPTION
## Description

- deps: Consume policy-evaluator 0.4.4. Adds support for signature verification via github_actions and keyless_prefix.
- build: Bump version to 1.1.0.

## Test

<!-- Please provides a short description about how to test your pullrequest -->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
