### PR TITLE
fix: Warn and continue when Sigstore TUF repository is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 ## [Unreleased]
 
 
+<a name="v1.1.1"></a>
+## [v1.1.1] - 2022-07-19
+### Bug Fixes
+- Warn and continue when Sigstore TUF repository is broken
+
+### Pull Requests
+- Merge pull request [#262](https://github.com/kubewarden/kwctl/issues/262) from kubewarden/road-to-1.1.0
+
+
 <a name="v1.1.0"></a>
 ## [v1.1.0] - 2022-07-14
 ### Bug Fixes
@@ -368,7 +377,8 @@
 - Merge pull request [#12](https://github.com/kubewarden/kwctl/issues/12) from ereslibre/drop-uri-named-arg
 
 
-[Unreleased]: https://github.com/kubewarden/kwctl/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/kubewarden/kwctl/compare/v1.1.1...HEAD
+[v1.1.1]: https://github.com/kubewarden/kwctl/compare/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/kubewarden/kwctl/compare/v1.0.1...v1.1.0
 [v1.0.1]: https://github.com/kubewarden/kwctl/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/kubewarden/kwctl/compare/v1.0.0-rc4...v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 [[package]]
 name = "burrego"
 version = "0.1.3"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.4#e47bda8e9667e767d7c1fa35d7401f6a6d62e96e"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.5#80f96c08841cab79961aa5683776ebcbfd5bfa7b"
 dependencies = [
  "anyhow",
  "base64",
@@ -2028,9 +2028,9 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "kube"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68b954ea9ad888de953fb1488bd8f377c4c78d82d4642efa5925189210b50b7"
+checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2039,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150dc7107d9acf4986088f284a0a6dddc5ae37ef1ffdf142f6811dc5998dd58"
+checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
 dependencies = [
  "base64",
  "bytes",
@@ -2075,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
+checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2782,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "path-slash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
+checksum = "c54014ba3c1880122928735226f78b6f5bf5bd1fed15e41e92cf7aa20278ce28"
 
 [[package]]
 name = "pathdiff"
@@ -3019,8 +3019,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.4.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.4#e47bda8e9667e767d7c1fa35d7401f6a6d62e96e"
+version = "0.4.5"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.5#80f96c08841cab79961aa5683776ebcbfd5bfa7b"
 dependencies = [
  "anyhow",
  "base64",
@@ -3047,8 +3047,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.7.8"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.7.8#7d710f303b54fb6aa7e971a18a17338fd8feaee9"
+version = "0.7.9"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.7.9#e3145ce66a2ca952128983f6e3fcc77c41d3a259"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3779,7 +3779,8 @@ dependencies = [
 [[package]]
 name = "sigstore"
 version = "0.3.2"
-source = "git+https://github.com/sigstore/sigstore-rs?rev=v0.3.2#8320a7fcb90ed393c3075aa50943ffd1e61e040a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03665d79a0eba79810d49a6c4f7aa0bcd157d93b50bf89aabf48cb1cb1d74be"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.10.3"
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_24"] }
 lazy_static = "1.4.0"
 mdcat = "0.27.1"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.4" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.5" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.9.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]

--- a/src/run.rs
+++ b/src/run.rs
@@ -28,7 +28,7 @@ pub(crate) async fn pull_and_run(
     request: &str,
     settings: Option<String>,
     verified_manifest_digest: &Option<String>,
-    fulcio_and_rekor_data: &FulcioAndRekorData,
+    fulcio_and_rekor_data: Option<&FulcioAndRekorData>,
     enable_wasmtime_cache: bool,
 ) -> Result<()> {
     let uri = crate::utils::map_path_to_uri(uri)?;

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -15,7 +15,7 @@ pub(crate) async fn verify(
     docker_config: Option<&DockerConfig>,
     sources: Option<&Sources>,
     verification_config: &LatestVerificationConfig,
-    fulcio_and_rekor_data: &FulcioAndRekorData,
+    fulcio_and_rekor_data: Option<&FulcioAndRekorData>,
 ) -> Result<String> {
     debug!(policy = url, "Verifying policy");
     let mut verifier = Verifier::new(sources.cloned(), fulcio_and_rekor_data)?;
@@ -32,7 +32,7 @@ pub(crate) async fn verify_local_checksum(
     docker_config: Option<&DockerConfig>,
     sources: Option<&Sources>,
     verified_manifest_digest: &str,
-    fulcio_and_rekor_data: &FulcioAndRekorData,
+    fulcio_and_rekor_data: Option<&FulcioAndRekorData>,
 ) -> Result<()> {
     let mut verifier = Verifier::new(sources.cloned(), fulcio_and_rekor_data)?;
     verifier


### PR DESCRIPTION
## Description

Allow Fulcio and Rekor data to be None. This means we will be missing
info from the transparency log, therefore not being able to validate
correct signatures, and giving false negatives.

Warn about it, and continue.

This protects us when upstream's Sigstore TUF repository has problems.

```
$ ./kwctl verify --verification-config-path=./../../e2e-tests/test-data/sigstore/verification-config-keyless.yml registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9

2022-07-19T09:57:04.387681Z  WARN kwctl: Cannot fetch TUF repository: TufError(ParseMetadata { role: Targets, source: Error("missing field `length`", line: 24, column: 4), backtrace: Backtrace(()) })
2022-07-19T09:57:04.387762Z  WARN policy_fetcher::verify: Sigstore Verifier created without Fulcio data: keyless signatures are going to be discarded because they cannot be verified
2022-07-19T09:57:04.387771Z  WARN policy_fetcher::verify: Sigstore Verifier created without Rekor data: transparency log data won't be used
2022-07-19T09:57:04.387781Z  WARN policy_fetcher::verify: Sigstore capabilities are going to be limited
Error: Policy registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9 cannot be validated
No Signature Layer passed verification
```

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Tested manually, the malformed metadata is still available.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
