### PR TITLE
fix: Reenable TUF integration test

### DIFF
--- a/e2e-tests/secure_supply_chain_tests.bats
+++ b/e2e-tests/secure_supply_chain_tests.bats
@@ -67,18 +67,18 @@ kwctl() {
     [ $(expr "$output" : '.*--sources-path.*') -ne 0 ]
 }
 
-# @test "[Secure supply chain  tests] Check TUF integration" {
-#     mkdir -p "$XDG_CONFIG_HOME"/kubewarden/fulcio_and_rekor_data
-#     FULCIO_AND_REKOR_DATA_DIR=$(readlink -f "$XDG_CONFIG_HOME"/kubewarden/fulcio_and_rekor_data)
-#     rm -rf ${FULCIO_AND_REKOR_DATA_DIR}
-#     kwctl verify \
-#       --verification-config-path=test-data/sigstore/verification-config-keyless.yml \
-#       registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
-#     [ "$status" -eq 0 ]
-#     [ -f ${FULCIO_AND_REKOR_DATA_DIR}/fulcio.crt.pem ]
-#     [ -f ${FULCIO_AND_REKOR_DATA_DIR}/fulcio_v1.crt.pem ]
-#     [ -f ${FULCIO_AND_REKOR_DATA_DIR}/rekor.pub ]
-# }
+@test "[Secure supply chain  tests] Check TUF integration" {
+    mkdir -p "$XDG_CONFIG_HOME"/kubewarden/fulcio_and_rekor_data
+    FULCIO_AND_REKOR_DATA_DIR=$(readlink -f "$XDG_CONFIG_HOME"/kubewarden/fulcio_and_rekor_data)
+    rm -rf ${FULCIO_AND_REKOR_DATA_DIR}
+    kwctl verify \
+      --verification-config-path=test-data/sigstore/verification-config-keyless.yml \
+      registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9
+    [ "$status" -eq 0 ]
+    [ -f ${FULCIO_AND_REKOR_DATA_DIR}/fulcio.crt.pem ]
+    [ -f ${FULCIO_AND_REKOR_DATA_DIR}/fulcio_v1.crt.pem ]
+    [ -f ${FULCIO_AND_REKOR_DATA_DIR}/rekor.pub ]
+}
 
 @test "[Secure supply chain  tests] verify a signed policy from an OCI registry" {
 


### PR DESCRIPTION
## Description

This reverts commit 5b1d93565200f2f21a1c3dd87197430fcd914c22.
Once the release was done, and the upstream TUF repository metadata is correct again,
we can re-enable this test.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

e2e-tests via GHA.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
