### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 [[package]]
 name = "burrego"
 version = "0.1.3"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.5#80f96c08841cab79961aa5683776ebcbfd5bfa7b"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.6#73e692b32d53093e2e64db4fe44a147ed40c3d2c"
 dependencies = [
  "anyhow",
  "base64",
@@ -419,7 +419,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.1",
  "tracing",
  "tracing-subscriber",
  "url 2.2.2",
@@ -476,13 +476,13 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d9447b2a367383a918fbbe62f6892da68000170c7331003d132b4805b63214"
+checksum = "1fb357e6e99f5d293f67f492dd3eb7f8c4d5ed7c48d22129f3464e57c9dd5394"
 dependencies = [
  "async-trait",
  "async_once",
- "cached_proc_macro 0.13.0",
+ "cached_proc_macro 0.14.0",
  "cached_proc_macro_types",
  "futures",
  "hashbrown 0.12.3",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4797df465f7409b55bab9ccd1edbf1d279ffdf763772c2804b96740ee72f3b82"
+checksum = "b01c8c46a3494c931456ad652aaab219cccd2785bdf3efbc00f733849d00df03"
 dependencies = [
  "cached_proc_macro_types",
  "darling",
@@ -2145,7 +2145,6 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "url 2.2.2",
- "validator",
  "walrus",
  "wasmparser 0.88.0",
 ]
@@ -3018,13 +3017,13 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.4.5"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.5#80f96c08841cab79961aa5683776ebcbfd5bfa7b"
+version = "0.4.6"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.6#73e692b32d53093e2e64db4fe44a147ed40c3d2c"
 dependencies = [
  "anyhow",
  "base64",
  "burrego",
- "cached 0.36.0",
+ "cached 0.37.0",
  "dns-lookup",
  "json-patch",
  "k8s-openapi",
@@ -3040,7 +3039,7 @@ dependencies = [
  "url 2.2.2",
  "validator",
  "wapc",
- "wasmparser 0.87.0",
+ "wasmparser 0.88.0",
  "wasmtime-provider",
 ]
 
@@ -4530,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07b0a1390e01c0fc35ebb26b28ced33c9a3808f7f9fbe94d3cc01e233bfeed5"
+checksum = "32ad5bf234c7d3ad1042e5252b7eddb2c4669ee23f32c7dd0e9b7705f07ef591"
 dependencies = [
  "idna 0.2.3",
  "lazy_static",
@@ -4546,9 +4545,9 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7ed5e8cf2b6bdd64a6c4ce851da25388a89327b17b88424ceced6bd5017923"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
 dependencies = [
  "if_chain",
  "lazy_static",
@@ -4562,9 +4561,9 @@ dependencies = [
 
 [[package]]
 name = "validator_types"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ddf34293296847abfc1493b15c6e2f5d3cd19f57ad7d22673bf4c6278da329"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -4818,15 +4817,6 @@ name = "wasmparser"
 version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "570460c58b21e9150d2df0eaaedbb7816c34bcec009ae0dcc976e40ba81463e7"
-dependencies = [
- "indexmap",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.87.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c04e207cd2e8ecb6f9bd28a2cf3119b4c6bfeee6fe3a25cc1daf8041d00a875"
 dependencies = [
  "indexmap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ checksum = "e54b86398b5852ddd45784b1d9b196b98beb39171821bad4b8b44534a1e87927"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "winapi",
 ]
 
@@ -545,10 +545,10 @@ dependencies = [
  "errno",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 0.33.7",
  "winapi",
  "winapi-util",
  "winx",
@@ -572,9 +572,9 @@ checksum = "2247568946095c7765ad2b441a56caffc08027734c634a6d5edda648f04e32eb"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "ipnet",
- "rustix",
+ "rustix 0.33.7",
 ]
 
 [[package]]
@@ -585,7 +585,7 @@ checksum = "c50472b6ebc302af0401fa3fb939694cd8ff00e0d4c9182001e434fc822ab83a"
 dependencies = [
  "cap-primitives",
  "once_cell",
- "rustix",
+ "rustix 0.33.7",
  "winx",
 ]
 
@@ -654,6 +654,7 @@ checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
  "once_cell",
@@ -669,6 +670,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1257,26 +1271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fehler"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5729fe49ba028cd550747b6e62cd3d841beccab5390aa398538c31a2d983635"
-dependencies = [
- "fehler-macros",
-]
-
-[[package]]
-name = "fehler-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb5acb1045ebbfa222e2c50679e392a71dd77030b78fb0189f2d9c5974400f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "file-per-thread-logger"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,8 +1331,8 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
 dependencies = [
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 0.5.3",
+ "rustix 0.33.7",
  "winapi",
 ]
 
@@ -1880,7 +1874,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c937cc9891c12eaa8c63ad347e4a288364b1328b924886970b47a14ab8f8f8"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "winapi",
 ]
 
@@ -1895,6 +1889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,8 +1907,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c89a757e762896bdbdfadf2860d0f8b0cea5e363d8cf3e7bdfeb63d1d976352"
 dependencies = [
  "hermit-abi 0.2.3",
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 0.5.3",
+ "rustix 0.33.7",
  "winapi",
 ]
 
@@ -2166,12 +2166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2209,12 @@ name = "linux-raw-sys"
 version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -2277,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "mdcat"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d61a88831141b0c2c172a84f1f950e4c7611a0bc9030ac79c4058528d7fd767"
+checksum = "c9991f58a121f49d297259c46f5fabd2f1a65d305167ad7b31c35a3bfce3ddfb"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2287,7 +2287,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "env_proxy",
- "fehler",
  "gethostname",
  "image",
  "libc",
@@ -3472,12 +3471,26 @@ checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "itoa 1.0.2",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.42",
  "once_cell",
  "winapi",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.7.2",
+ "libc",
+ "linux-raw-sys 0.0.46",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3948,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "4.6.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
+checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
 dependencies = [
  "bincode",
  "bitflags",
@@ -3958,13 +3971,14 @@ dependencies = [
  "flate2",
  "fnv",
  "lazy_static",
- "lazycell",
+ "once_cell",
  "onig",
  "plist",
  "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
  "walkdir",
  "yaml-rust",
 ]
@@ -3979,8 +3993,8 @@ dependencies = [
  "bitflags",
  "cap-fs-ext",
  "cap-std",
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 0.5.3",
+ "rustix 0.33.7",
  "winapi",
  "winx",
 ]
@@ -4027,12 +4041,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
- "libc",
- "winapi",
+ "rustix 0.35.7",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4690,10 +4704,10 @@ dependencies = [
  "cap-time-ext",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "is-terminal",
  "lazy_static",
- "rustix",
+ "rustix 0.33.7",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -4711,7 +4725,7 @@ dependencies = [
  "cap-rand",
  "cap-std",
  "io-extras",
- "rustix",
+ "rustix 0.33.7",
  "thiserror",
  "tracing",
  "wiggle",
@@ -4872,7 +4886,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix",
+ "rustix 0.33.7",
  "serde",
  "sha2 0.9.9",
  "toml",
@@ -4929,7 +4943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715afdb87a3bcf1eae3f098c742d650fb783abdb8a7ca87076ea1cabecabea5d"
 dependencies = [
  "cc",
- "rustix",
+ "rustix 0.33.7",
  "winapi",
 ]
 
@@ -4950,7 +4964,7 @@ dependencies = [
  "object 0.28.4",
  "region",
  "rustc-demangle",
- "rustix",
+ "rustix 0.33.7",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -4968,7 +4982,7 @@ checksum = "b252d1d025f94f3954ba2111f12f3a22826a0764a11c150c2d46623115a69e27"
 dependencies = [
  "lazy_static",
  "object 0.28.4",
- "rustix",
+ "rustix 0.33.7",
 ]
 
 [[package]]
@@ -5007,7 +5021,7 @@ dependencies = [
  "more-asserts",
  "rand",
  "region",
- "rustix",
+ "rustix 0.33.7",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -5246,7 +5260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d5973cb8cd94a77d03ad7e23bbe14889cb29805da1cec0e4aff75e21aebded"
 dependencies = [
  "bitflags",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.10.3"
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_24"] }
 lazy_static = "1.4.0"
 mdcat = "0.28"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.5" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.6" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
 pulldown-cmark = { version = "0.9.2", default-features = false }
@@ -32,7 +32,6 @@ tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 url = "2.2.2"
-validator = { version = "0.15", features = ["derive"] }
 walrus = "0.19.0"
 wasmparser = "0.88"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "3.0.15", features = [ "cargo", "env" ] }
-clap_complete = "3.1.4"
+clap = { version = "3.2", features = [ "cargo", "env" ] }
+clap_complete = "3.2"
 directories = "4.0.1"
 itertools = "0.10.3"
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_24"] }
 lazy_static = "1.4.0"
-mdcat = "0.27.1"
+mdcat = "0.28"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.5" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.8"
@@ -26,7 +26,7 @@ regex = "1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.1"
-syntect = "4.5.0"
+syntect = "5.0"
 tokio = { version = "^1", features = ["full"] }
 tracing = "0.1"
 tracing-futures = "0.2"

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,9 +1,9 @@
 use crate::backend::{Backend, BackendDetector};
 use anyhow::{anyhow, Result};
+use policy_evaluator::validator::Validate;
 use policy_evaluator::{constants::*, policy_metadata::Metadata, ProtocolVersion};
 use std::fs::File;
 use std::path::PathBuf;
-use validator::Validate;
 
 pub(crate) fn write_annotation(
     wasm_path: PathBuf,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,7 @@
-use clap::{crate_authors, crate_description, crate_name, crate_version, Arg, Command};
+use clap::{
+    builder::PossibleValuesParser, crate_authors, crate_description, crate_name, crate_version,
+    Arg, ArgAction, Command,
+};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 
@@ -55,7 +58,7 @@ pub fn build_cli() -> Command<'static> {
                     Arg::new("verification-key")
                     .short('k')
                     .long("verification-key")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Path to key used to verify the policy. Can be repeated multiple times")
@@ -63,7 +66,7 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("fulcio-cert-path")
                     .long("fulcio-cert-path")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Path to the Fulcio certificate. Can be repeated multiple times")
@@ -78,7 +81,7 @@ pub fn build_cli() -> Command<'static> {
                     Arg::new("verification-annotation")
                     .short('a')
                     .long("verification-annotation")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Annotation in key=value format. Can be repeated multiple times")
@@ -86,7 +89,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("cert-email")
                     .long("cert-email")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Expected email in Fulcio certificate")
@@ -94,7 +96,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("cert-oidc-issuer")
                     .long("cert-oidc-issuer")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Expected OIDC issuer in Fulcio certificates")
@@ -102,7 +103,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("github-owner")
                     .long("github-owner")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("GitHub owner expected in the certificates generated in CD pipelines")
@@ -110,7 +110,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("github-repo")
                     .long("github-repo")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("GitHub repository expected in the certificates generated in CD pipelines")
@@ -154,7 +153,7 @@ pub fn build_cli() -> Command<'static> {
                     Arg::new("verification-key")
                     .short('k')
                     .long("verification-key")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Path to key used to verify the policy. Can be repeated multiple times")
@@ -162,7 +161,7 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("fulcio-cert-path")
                     .long("fulcio-cert-path")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Path to the Fulcio certificate. Can be repeated multiple times")
@@ -177,7 +176,7 @@ pub fn build_cli() -> Command<'static> {
                     Arg::new("verification-annotation")
                     .short('a')
                     .long("verification-annotation")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Annotation in key=value format. Can be repeated multiple times")
@@ -185,7 +184,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("cert-email")
                     .long("cert-email")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Expected email in Fulcio certificate")
@@ -193,7 +191,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("cert-oidc-issuer")
                     .long("cert-oidc-issuer")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Expected OIDC issuer in Fulcio certificates")
@@ -201,7 +198,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("github-owner")
                     .long("github-owner")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("GitHub owner expected in the certificates generated in CD pipelines")
@@ -209,7 +205,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("github-repo")
                     .long("github-repo")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("GitHub repository expected in the certificates generated in CD pipelines")
@@ -247,7 +242,7 @@ pub fn build_cli() -> Command<'static> {
                     .long("output")
                     .short('o')
                     .takes_value(true)
-                    .possible_values(&["text", "json"])
+                    .value_parser(PossibleValuesParser::new(["text", "json"]))
                     .default_value("text")
                     .help("Output format")
                 )
@@ -320,7 +315,7 @@ pub fn build_cli() -> Command<'static> {
                     Arg::new("verification-key")
                     .short('k')
                     .long("verification-key")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Path to key used to verify the policy. Can be repeated multiple times")
@@ -328,7 +323,7 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("fulcio-cert-path")
                     .long("fulcio-cert-path")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Path to the Fulcio certificate. Can be repeated multiple times")
@@ -343,7 +338,7 @@ pub fn build_cli() -> Command<'static> {
                     Arg::new("verification-annotation")
                     .short('a')
                     .long("verification-annotation")
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Annotation in key=value format. Can be repeated multiple times")
@@ -351,7 +346,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("cert-email")
                     .long("cert-email")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Expected email in Fulcio certificate")
@@ -359,7 +353,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("cert-oidc-issuer")
                     .long("cert-oidc-issuer")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("Expected OIDC issuer in Fulcio certificates")
@@ -367,7 +360,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("github-owner")
                     .long("github-owner")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("GitHub owner expected in the certificates generated in CD pipelines")
@@ -375,7 +367,6 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("github-repo")
                     .long("github-repo")
-                    .multiple_occurrences(false)
                     .number_of_values(1)
                     .takes_value(true)
                     .help("GitHub repository expected in the certificates generated in CD pipelines")
@@ -385,7 +376,7 @@ pub fn build_cli() -> Command<'static> {
                     .long("execution-mode")
                     .short('e')
                     .takes_value(true)
-                    .possible_values(&["opa","gatekeeper", "kubewarden"])
+                    .value_parser(PossibleValuesParser::new(["opa","gatekeeper", "kubewarden"]))
                     .help("The runtime to use to execute this policy")
                 )
                 .arg(
@@ -434,7 +425,7 @@ pub fn build_cli() -> Command<'static> {
                     .long("output")
                     .short('o')
                     .takes_value(true)
-                    .possible_values(&["yaml"])
+                    .value_parser(PossibleValuesParser::new(["yaml"]))
                     .help("Output format")
                 )
                 .arg(
@@ -486,7 +477,7 @@ pub fn build_cli() -> Command<'static> {
                             .short('t')
                             .required(true)
                             .takes_value(true)
-                            .possible_values(&["ClusterAdmissionPolicy", "AdmissionPolicy"])
+                            .value_parser(PossibleValuesParser::new(["ClusterAdmissionPolicy", "AdmissionPolicy"]))
                             .help("Kubewarden Custom Resource type")
                         )
                         .arg(
@@ -512,7 +503,7 @@ pub fn build_cli() -> Command<'static> {
                     .short('s')
                     .takes_value(true)
                     .required(true)
-                    .possible_values(&["bash", "fish", "zsh", "elvish", "powershell"])
+                    .value_parser(PossibleValuesParser::new(["bash", "fish", "zsh", "elvish", "powershell"]))
                     .help("Shell type")
                 )
         )

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Result};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use policy_evaluator::validator::Validate;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use validator::Validate;
 
 use policy_evaluator::constants::KUBEWARDEN_ANNOTATION_POLICY_TITLE;
 use policy_evaluator::policy_fetcher::verify::config::{


### PR DESCRIPTION
The mdbook dependency caused an upgrade of the clap one in an indirect fashion. That lead me to be explicit about the version fo clap to be used.

The clap update requried several fixes because of some deprecation warnings. Everything is working fine according to the e2e tests.

Supersedes PR https://github.com/kubewarden/kwctl/pull/274

**UPDATE**

I've also updated the `validator` crate, which could not be handled via dependabot. This one requires https://github.com/kubewarden/policy-evaluator/pull/166 to merged and a new version of `policy-evaluator` to be tagged.

Once this is done I'll update the `Cargo.toml` accordingly.

Now this PR supersedes also https://github.com/kubewarden/kwctl/pull/270

