### PR TITLE
ci: Added CI Job to release Apple Silicon binary with the release GH Actions flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
       - build-linux-x86_64
       - build-linux-aarch64
       - build-darwin-x86_64
+      - build-darwin-aarch64
       - build-windows-x86_64
     steps:
     - name: Create Release
@@ -224,6 +225,17 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: kwctl-darwin-x86_64
+
+    - name: Download darwin-aarch64 binary
+      uses: actions/download-artifact@v2
+      with:
+        name: kwctl-darwin-aarch64
+
+    - name: Download darwin-aarch64 binary
+      uses: actions/download-artifact@v2
+      with:
+        name: kwctl-darwin-aarch64
+
     - name: Publish darwin-x86_64 binary
       uses: actions/upload-release-asset@v1
       env:
@@ -232,6 +244,16 @@ jobs:
         upload_url: ${{ steps.create-release.outputs.upload_url }}
         asset_name: kwctl-darwin-x86_64.zip
         asset_path: kwctl-darwin-x86_64.zip
+        asset_content_type: application/zip
+
+    - name: Publish darwin-aarch64 binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create-release.outputs.upload_url }}
+        asset_name: kwctl-darwin-aarch64.zip
+        asset_path: kwctl-darwin-aarch64.zip
         asset_content_type: application/zip
 
     - name: Download windows-x86_64 binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,37 @@ jobs:
         name: kwctl-linux-aarch64
         path: kwctl-linux-aarch64.zip
 
+  build-darwin-aarch64:
+    name: Build darwin (aarch64) Apple Silicon binary
+    runs-on: macos-latest
+    permissions:
+      id-token: write
+    needs:
+      - ci
+    steps:
+    - uses: actions/checkout@v2
+    - uses: sigstore/cosign-installer@main
+    - name: Setup rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: aarch64-apple-darwin
+        override: true
+    - run: rustup target add aarch64-apple-darwin
+    - name: Build kwctl
+      run: cargo build --target=aarch64-apple-darwin --release
+    - run: mv target/aarch64-apple-darwin/release/kwctl kwctl-darwin-aarch64
+    - name: Sign kwctl
+      run: cosign sign-blob kwctl-darwin-aarch64 --output-certificate kwctl-darwin-aarch64.pem --output-signature kwctl-darwin-aarch64.sig
+      env:
+        COSIGN_EXPERIMENTAL: 1
+    - run: zip -j9 kwctl-darwin-aarch64.zip kwctl-darwin-aarch64 kwctl-darwin-aarch64.sig kwctl-darwin-aarch64.pem
+    - name: Upload binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: kwctl-darwin-aarch64
+        path: kwctl-darwin-aarch64.zip
+
   build-darwin-x86_64:
     name: Build darwin (x86_64) binary
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,11 +231,6 @@ jobs:
       with:
         name: kwctl-darwin-aarch64
 
-    - name: Download darwin-aarch64 binary
-      uses: actions/download-artifact@v2
-      with:
-        name: kwctl-darwin-aarch64
-
     - name: Publish darwin-x86_64 binary
       uses: actions/upload-release-asset@v1
       env:


### PR DESCRIPTION
## Description

This PR involves just a CI Job to be executed on release time.

- [x] Added new target `aarch64-apple-darwin` on `release.yml` which supports Apple Silicon processors from new M1/M2 Mac 

## Test
To test this pull request, you can run the following commands:

```shell
rustup target add aarch64-apple-darwin
cargo build --target=aarch64-apple-darwin --release
```

## Additional Information

I already validated that it works on a M1 processor

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>
