### PR TITLE
 Use Musl from Ubuntu packages.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,9 +4,7 @@
 # More information: https://github.com/rust-lang/cargo/issues/4133
 
 [target.x86_64-unknown-linux-musl]
-linker = "x86_64-linux-musl-ld"
-ar = "x86_64-linux-musl-ar"
+linker = "x86_64-linux-musl-gcc"
 
 [target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-musl-ld"
-ar = "aarch64-linux-musl-ar"
+linker = "aarch64-linux-musl-gcc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,75 +11,91 @@ jobs:
     # A branch is required, and cannot be dynamic - https://github.com/actions/runner/issues/1493
     uses: kubewarden/kwctl/.github/workflows/tests.yml@main
 
-  build-linux-x86_64:
-    name: Build linux (x86_64) binary
-    runs-on: ubuntu-latest
+  build-linux-binaries:
+    name: Build linux binary
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        targetarch: [ "aarch64", "x86_64" ]
+        include:
+          - targetarch: aarch64
+            arch: arm64
+            rustflags: ""
+          - targetarch: x86_64
+            arch: amd64
+            rustflags: "-C target-feature=+crt-static"
     permissions:
+      packages: write
       id-token: write
     needs:
       - ci
     steps:
-    - uses: actions/checkout@v2
-    - uses: sigstore/cosign-installer@main
-    - name: Setup rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - name: Setup musl for x86_64
-      run: |
-        curl https://musl.cc/x86_64-linux-musl-cross.tgz | tar -xz
-        echo "$PWD/x86_64-linux-musl-cross/bin" >> $GITHUB_PATH
-    - run: rustup target add x86_64-unknown-linux-musl
-    - name: Build kwctl
-      env:
-        CC: x86_64-linux-musl-gcc
-      run: cargo build --target=x86_64-unknown-linux-musl --release
-    - run: mv target/x86_64-unknown-linux-musl/release/kwctl kwctl-linux-x86_64
-    - name: Sign kwctl
-      run: cosign sign-blob kwctl-linux-x86_64 --output-certificate kwctl-linux-x86_64.pem --output-signature kwctl-linux-x86_64.sig
-      env:
-        COSIGN_EXPERIMENTAL: 1
-    - run: zip -j9 kwctl-linux-x86_64.zip kwctl-linux-x86_64 kwctl-linux-x86_64.sig kwctl-linux-x86_64.pem
-    - name: Upload binary
-      uses: actions/upload-artifact@v2
-      with:
-        name: kwctl-linux-x86_64
-        path: kwctl-linux-x86_64.zip
+      - name: Configure Ubuntu repositories
+        run: |
+          sudo dpkg --add-architecture arm64
 
-  build-linux-aarch64:
-    name: Build linux (aarch64) binary
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    needs:
-      - ci
-    steps:
-    - uses: actions/checkout@v2
-    - uses: sigstore/cosign-installer@main
-    - name: Setup rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - name: Setup musl for aarch64
-      run: |
-        curl https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz
-        echo "$PWD/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
-    - run: rustup target add aarch64-unknown-linux-musl
-    - name: Build kwctl
-      env:
-        CC: aarch64-linux-musl-gcc
-      run: cargo build --target=aarch64-unknown-linux-musl --release
-    - run: mv target/aarch64-unknown-linux-musl/release/kwctl kwctl-linux-aarch64
-    - name: Sign kwctl
-      run: cosign sign-blob kwctl-linux-aarch64 --output-certificate kwctl-linux-aarch64.pem --output-signature kwctl-linux-aarch64.sig
-      env:
-        COSIGN_EXPERIMENTAL: 1
-    - run: zip -j9 kwctl-linux-aarch64.zip kwctl-linux-aarch64 kwctl-linux-aarch64.sig kwctl-linux-aarch64.pem
-    - name: Upload binary
-      uses: actions/upload-artifact@v2
-      with:
-        name: kwctl-linux-aarch64
-        path: kwctl-linux-aarch64.zip
+          sudo sed -i "s/deb h/deb [arch=amd64] h/g" /etc/apt/sources.list
+
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy universe" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates universe" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy multiverse" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates multiverse" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security universe" /etc/apt/sources.list
+          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security multiverse" /etc/apt/sources.list
+
+          sudo apt update -y
+      - name: Install Musl and configure gcc spec
+        run: |
+          sudo apt install -y musl-dev:${{ matrix.arch }}
+          # patching the .spec file, as by default it has a bug where it tries to
+          # set old_cpp_options but it already exists. using *+cpp_options achieves
+          # the same desired functionality of appending preexisting options
+          sudo sed -i 1d /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
+          sudo sed -i "s/*cpp_options/+cpp_options/g" /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
+          sudo sed -i "s/ %(old_cpp_options)//g" /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
+
+      - name: Configure gcc spec for x86_64
+        if: ${{ matrix.targetarch == 'x86_64' }}
+        run: |
+          # The cargo configuration to build static binaries is not working. Thus,
+          # update the spec file to ensure that.
+          sudo sed -i "s/-dynamic-linker.*/-no-dynamic-linker  -nostdlib %{shared:-shared} %{static:-static} %{rdynamic:-no-export-dynamic}/g" /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
+
+      - uses: sigstore/cosign-installer@main
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install rust target
+        run: rustup target add ${{ matrix.targetarch }}-unknown-linux-musl
+
+      - name: Build kwctl
+        env:
+          CC: ${{ matrix.targetarch }}-linux-musl-gcc
+          RUSTFLAGS: "-C link_arg=-lgcc -C link_arg=-specs -C link_arg=/usr/lib/${{ matrix.targetarch}}-linux-musl/musl-gcc.specs ${{ matrix.rustflags }}"
+        run: |
+          cargo build --release --target ${{ matrix.targetarch }}-unknown-linux-musl
+          mv target/${{ matrix.targetarch }}-unknown-linux-musl/release/kwctl kwctl-linux-${{ matrix.targetarch }}
+
+      - name: Sign kwctl
+        run: cosign sign-blob kwctl-linux-${{ matrix.targetarch }} --output-certificate kwctl-linux-${{ matrix.targetarch}}.pem --output-signature kwctl-linux-${{ matrix.targetarch }}.sig
+        env:
+          COSIGN_EXPERIMENTAL: 1
+      - run: zip -j9 kwctl-linux-${{ matrix.targetarch }}.zip kwctl-linux-${{ matrix.targetarch }} kwctl-linux-${{ matrix.targetarch }}.sig kwctl-linux-${{ matrix.targetarch }}.pem
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: kwctl-linux-${{ matrix.targetarch }}
+          path: kwctl-linux-${{ matrix.targetarch }}.zip
 
   build-darwin-aarch64:
     name: Build darwin (aarch64) Apple Silicon binary
@@ -176,8 +192,7 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     needs:
-      - build-linux-x86_64
-      - build-linux-aarch64
+      - build-linux-binaries
       - build-darwin-x86_64
       - build-darwin-aarch64
       - build-windows-x86_64


### PR DESCRIPTION
After a DDoS attack the maintainer of the musl.cc domains blocked the
request caming from some cloud providers. This prevent us from
downloading the tarball needed to cross-compile the policy-server.
Therefore, the workflow has been updated to use the musl package
available in the Ubuntu 22.04 packages.

Fix #281 