### PR TITLE
Road to 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,30 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+
+<a name="v1.1.3"></a>
+## [v1.1.3] - 2022-08-24
+### Reverts
+- Merge pull request [#292](https://github.com/kubewarden/kwctl/issues/292) from viccuad/road-to-1.2.0
+
+### Pull Requests
+- Merge pull request [#292](https://github.com/kubewarden/kwctl/issues/292) from viccuad/road-to-1.2.0
+- Merge pull request [#288](https://github.com/kubewarden/kwctl/issues/288) from kubewarden/dependabot/cargo/wasmparser-0.89.1
+- Merge pull request [#286](https://github.com/kubewarden/kwctl/issues/286) from kubewarden/dependabot/cargo/prettytable-rs-0.9.0
+- Merge pull request [#285](https://github.com/kubewarden/kwctl/issues/285) from viccuad/main
+
+
 <a name="v1.1.2"></a>
-## [v1.1.2] - 2022-08-10
+## [v1.1.2] - 2022-08-11
 ### Bug Fixes
 - **deps:** update rust crate serde_yaml to 0.9.4
 - **deps:** update rust crate pulldown-cmark to 0.9.2
 
 ### Features
-- Use docker_credential crate instead of DockerConfig
-- Added CI Job to release Apple Silicon binary with the release GH Actions flow
+- use docker_credential crate instead of DockerConfig
+
+### Reverts
+- fix: Disable TUF integration test for now
 
 ### Pull Requests
 - Merge pull request [#277](https://github.com/kubewarden/kwctl/issues/277) from raulcabello/docker_credential
@@ -18,6 +33,7 @@
 - Merge pull request [#271](https://github.com/kubewarden/kwctl/issues/271) from kubewarden/dependabot/cargo/wasmparser-0.88.0
 - Merge pull request [#272](https://github.com/kubewarden/kwctl/issues/272) from kubewarden/dependabot/cargo/serde_yaml-0.9.1
 - Merge pull request [#273](https://github.com/kubewarden/kwctl/issues/273) from kubewarden/renovate/all-patch
+- Merge pull request [#268](https://github.com/kubewarden/kwctl/issues/268) from viccuad/revert-tuf-test
 
 
 <a name="v1.1.1"></a>
@@ -28,6 +44,7 @@
 - **deps:** update rust crate serde_yaml to 0.8.26
 
 ### Pull Requests
+- Merge pull request [#267](https://github.com/kubewarden/kwctl/issues/267) from viccuad/main
 - Merge pull request [#265](https://github.com/kubewarden/kwctl/issues/265) from viccuad/tuf-fix
 - Merge pull request [#263](https://github.com/kubewarden/kwctl/issues/263) from kubewarden/renovate/all-patch
 - Merge pull request [#264](https://github.com/kubewarden/kwctl/issues/264) from kubewarden/renovate/lock-file-maintenance
@@ -400,7 +417,9 @@
 - Merge pull request [#12](https://github.com/kubewarden/kwctl/issues/12) from ereslibre/drop-uri-named-arg
 
 
-[Unreleased]: https://github.com/kubewarden/kwctl/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/kubewarden/kwctl/compare/v1.1.3...HEAD
+[v1.1.3]: https://github.com/kubewarden/kwctl/compare/v1.1.2...v1.1.3
+[v1.1.2]: https://github.com/kubewarden/kwctl/compare/v1.1.1...v1.1.2
 [v1.1.1]: https://github.com/kubewarden/kwctl/compare/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/kubewarden/kwctl/compare/v1.0.1...v1.1.0
 [v1.0.1]: https://github.com/kubewarden/kwctl/compare/v1.0.0...v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,15 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
-
-<a name="v1.2.0"></a>
-## [v1.2.0] - 2022-08-24
-### Pull Requests
-- Merge pull request [#288](https://github.com/kubewarden/kwctl/issues/288) from kubewarden/dependabot/cargo/wasmparser-0.89.1
-- Merge pull request [#286](https://github.com/kubewarden/kwctl/issues/286) from kubewarden/dependabot/cargo/prettytable-rs-0.9.0
-- Merge pull request [#285](https://github.com/kubewarden/kwctl/issues/285) from viccuad/main
-
-
 <a name="v1.1.2"></a>
-## [v1.1.2] - 2022-08-11
+## [v1.1.2] - 2022-08-10
 ### Bug Fixes
 - **deps:** update rust crate serde_yaml to 0.9.4
 - **deps:** update rust crate pulldown-cmark to 0.9.2
 
 ### Features
-- use docker_credential crate instead of DockerConfig
-
-### Reverts
-- fix: Disable TUF integration test for now
+- Use docker_credential crate instead of DockerConfig
+- Added CI Job to release Apple Silicon binary with the release GH Actions flow
 
 ### Pull Requests
 - Merge pull request [#277](https://github.com/kubewarden/kwctl/issues/277) from raulcabello/docker_credential
@@ -29,7 +18,6 @@
 - Merge pull request [#271](https://github.com/kubewarden/kwctl/issues/271) from kubewarden/dependabot/cargo/wasmparser-0.88.0
 - Merge pull request [#272](https://github.com/kubewarden/kwctl/issues/272) from kubewarden/dependabot/cargo/serde_yaml-0.9.1
 - Merge pull request [#273](https://github.com/kubewarden/kwctl/issues/273) from kubewarden/renovate/all-patch
-- Merge pull request [#268](https://github.com/kubewarden/kwctl/issues/268) from viccuad/revert-tuf-test
 
 
 <a name="v1.1.1"></a>
@@ -40,7 +28,6 @@
 - **deps:** update rust crate serde_yaml to 0.8.26
 
 ### Pull Requests
-- Merge pull request [#267](https://github.com/kubewarden/kwctl/issues/267) from viccuad/main
 - Merge pull request [#265](https://github.com/kubewarden/kwctl/issues/265) from viccuad/tuf-fix
 - Merge pull request [#263](https://github.com/kubewarden/kwctl/issues/263) from kubewarden/renovate/all-patch
 - Merge pull request [#264](https://github.com/kubewarden/kwctl/issues/264) from kubewarden/renovate/lock-file-maintenance
@@ -413,9 +400,7 @@
 - Merge pull request [#12](https://github.com/kubewarden/kwctl/issues/12) from ereslibre/drop-uri-named-arg
 
 
-[Unreleased]: https://github.com/kubewarden/kwctl/compare/v1.2.0...HEAD
-[v1.2.0]: https://github.com/kubewarden/kwctl/compare/v1.1.2...v1.2.0
-[v1.1.2]: https://github.com/kubewarden/kwctl/compare/v1.1.1...v1.1.2
+[Unreleased]: https://github.com/kubewarden/kwctl/compare/v1.1.1...HEAD
 [v1.1.1]: https://github.com/kubewarden/kwctl/compare/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/kubewarden/kwctl/compare/v1.0.1...v1.1.0
 [v1.0.1]: https://github.com/kubewarden/kwctl/compare/v1.0.0...v1.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.2.0"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.2.0"
+version = "1.1.2"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]


### PR DESCRIPTION
Revert PR about making `v1.2.0`, we will go with `v1.1.3`, as `v1.1.2` was tagged already yet unreleased because of the musl cross-compiling issues.