### PR TITLE
 feat: Support metadata.backgroundAudit 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -107,7 +107,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -195,11 +195,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -420,7 +421,7 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "burrego"
 version = "0.2.0"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.11#9930a622ac62e1538a7646467d9b4d58064f0ecd"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.12#d1cd00631296027ee2e000725158b95898770e9e"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -471,6 +472,25 @@ name = "cached"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e27085975166ffaacbd04527132e1cf5906fa612991f9b4fea08e787da2961"
+dependencies = [
+ "async-trait",
+ "async_once",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown",
+ "instant",
+ "lazy_static",
+ "once_cell",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "cached"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b4147cd94d5fbdc2ab71b11d50a2f45493625576b3bb70257f59eedea69f3d"
 dependencies = [
  "async-trait",
  "async_once",
@@ -1727,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -2347,9 +2367,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libm"
@@ -2529,14 +2549,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2801,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "openidconnect"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26afc60b2bf11b9a039db1f3a3c0d5fe201eebdbe646a8ecb8342c8240e3271"
+checksum = "87af7097640fedbe64718ac1c9b0549d72da747a3f527cd089215f96c6f691d5"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -3243,13 +3263,13 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.4.11"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.11#9930a622ac62e1538a7646467d9b4d58064f0ecd"
+version = "0.4.12"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.12#d1cd00631296027ee2e000725158b95898770e9e"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
  "burrego",
- "cached",
+ "cached 0.40.0",
  "dns-lookup",
  "json-patch",
  "k8s-openapi",
@@ -3265,7 +3285,7 @@ dependencies = [
  "url",
  "validator",
  "wapc",
- "wasmparser 0.92.0",
+ "wasmparser 0.93.0",
  "wasmtime-provider",
 ]
 
@@ -4078,7 +4098,7 @@ checksum = "cc814ce221da3ad80e304d35ae85fbc70fc8b8ea6ba72bd0ae3330958fd9598f"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
- "cached",
+ "cached 0.39.0",
  "digest 0.10.5",
  "ecdsa",
  "ed25519",
@@ -4404,21 +4424,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
  "itoa 1.0.4",
  "libc",
  "num_threads",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -5040,9 +5071,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64ac98d5d61192cc45c701b7e4bd0b9aff91e2edfc7a088406cfe2288581e2c"
+checksum = "c5816e88e8ea7335016aa62eb0485747f786136d505a9b3890f8c400211d9b5f"
 dependencies = [
  "leb128",
 ]
@@ -5058,15 +5089,6 @@ name = "wasmparser"
 version = "0.89.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5d3e08b13876f96dd55608d03cd4883a0545884932d5adf11925876c96daef"
-dependencies = [
- "indexmap",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.92.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da34cec2a8c23db906cdf8b26e988d7a7f0d549eb5d51299129647af61a1b37"
 dependencies = [
  "indexmap",
 ]
@@ -5310,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "47.0.1"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b98502f3978adea49551e801a6687678e6015317d7d9470a67fe813393f2a8"
+checksum = "84825b5ac7164df8260c9e2b2e814075334edbe7ac426f2469b93a5eeac23cce"
 dependencies = [
  "leb128",
  "memchr",
@@ -5322,11 +5344,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aab4e20c60429fbba9670a6cae0fff9520046ba0aa3e6d0b1cd2653bea14898"
+checksum = "129da4a03ec6d2a815f42c88f641824e789d5be0d86d2f90aa8a218c7068e0be"
 dependencies = [
- "wast 47.0.1",
+ "wast 48.0.0",
 ]
 
 [[package]]
@@ -5594,7 +5616,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.10.5"
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_25"] }
 lazy_static = "1.4.0"
 mdcat = "0.29"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.11" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.12" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.9"
 pulldown-cmark = { version = "0.9.2", default-features = false }

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -102,6 +102,7 @@ mod tests {
           resources: ["pods"]
           operations: ["CREATE", "UPDATE"]
         mutating: false
+        backgroundAudit: true
         annotations:
           io.kubewarden.policy.title: {}
         "#,
@@ -150,6 +151,7 @@ mod tests {
           resources: ["pods"]
           operations: ["CREATE", "UPDATE"]
         mutating: false
+        backgroundAudit: true
         annotations:
           io.kubewarden.policy.title: {}
           {}: NOT_VALID
@@ -198,6 +200,7 @@ mod tests {
           resources: ["pods"]
           operations: ["CREATE", "UPDATE"]
         mutating: false
+        backgroundAudit: true
         executionMode: kubewarden-wapc
         "#
         );
@@ -238,6 +241,7 @@ mod tests {
           resources: ["pods"]
           operations: ["CREATE", "UPDATE"]
         mutating: false
+        backgroundAudit: true
         executionMode: opa
         "#,
         );

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -144,7 +144,7 @@ impl MetadataPrinter {
             }
         }
         table.add_row(row![Fgbl -> "mutating:", metadata.mutating]);
-        table.add_row(row![Fgbl -> "backgroundAudit:", metadata.background_audit]);
+        table.add_row(row![Fgbl -> "background audit support:", metadata.background_audit]);
         table.add_row(row![Fgbl -> "context aware:", metadata.context_aware]);
         table.add_row(row![Fgbl -> "execution mode:", metadata.execution_mode]);
         if metadata.execution_mode == PolicyExecutionMode::KubewardenWapc {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -144,6 +144,7 @@ impl MetadataPrinter {
             }
         }
         table.add_row(row![Fgbl -> "mutating:", metadata.mutating]);
+        table.add_row(row![Fgbl -> "backgroundAudit:", metadata.background_audit]);
         table.add_row(row![Fgbl -> "context aware:", metadata.context_aware]);
         table.add_row(row![Fgbl -> "execution mode:", metadata.execution_mode]);
         if metadata.execution_mode == PolicyExecutionMode::KubewardenWapc {

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -27,6 +27,7 @@ struct ClusterAdmissionPolicySpec {
     settings: serde_yaml::Mapping,
     rules: Vec<Rule>,
     mutating: bool,
+    background_audit: bool,
 }
 
 impl TryFrom<ScaffoldData> for ClusterAdmissionPolicy {
@@ -46,6 +47,7 @@ impl TryFrom<ScaffoldData> for ClusterAdmissionPolicy {
                 settings: data.settings,
                 rules: data.metadata.rules.clone(),
                 mutating: data.metadata.mutating,
+                background_audit: data.metadata.background_audit,
             },
         })
     }
@@ -67,6 +69,7 @@ struct AdmissionPolicySpec {
     settings: serde_yaml::Mapping,
     rules: Vec<Rule>,
     mutating: bool,
+    background_audit: bool,
 }
 
 impl TryFrom<ScaffoldData> for AdmissionPolicy {
@@ -86,6 +89,7 @@ impl TryFrom<ScaffoldData> for AdmissionPolicy {
                 settings: data.settings,
                 rules: data.metadata.rules.clone(),
                 mutating: data.metadata.mutating,
+                background_audit: data.metadata.background_audit,
             },
         })
     }
@@ -204,6 +208,7 @@ mod tests {
             rules: vec![],
             annotations: None,
             mutating: false,
+            background_audit: true,
             context_aware: false,
             execution_mode: Default::default(),
         }
@@ -218,6 +223,7 @@ mod tests {
                 title,
             )])),
             mutating: false,
+            background_audit: true,
             context_aware: false,
             execution_mode: Default::default(),
         }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Depends on https://github.com/kubewarden/policy-evaluator/pull/197
Fix https://github.com/kubewarden/kwctl/issues/330
Fix https://github.com/kubewarden/kwctl/issues/331

`kwctl annotate` will default it to `true` if not provided.
`kwctl scaffold` will default it to `true` if not provided.
`kwctl inspect` shows it, defaulting to `true` if not present.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested in policy-evaluator.
Backwards compatibility is working; the e2e tests pass, without needing to re-annotate the policies with `backgroundAudit`.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
