### PR TITLE
Add read-all permission to all workflows

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,10 @@ on:
       - 'v*'
     branches:
       - 'main'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     - 'v*'
 env:
   CARGO_TERM_COLOR: always
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   ci:
     # A branch is required, and cannot be dynamic - https://github.com/actions/runner/issues/1493

--- a/.github/workflows/security-audit-cron.yml
+++ b/.github/workflows/security-audit-cron.yml
@@ -2,6 +2,10 @@ name: Security audit cron job
 on:
   schedule:
     - cron: '0 0 * * *'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-audit-reactive.yml
+++ b/.github/workflows/security-audit-reactive.yml
@@ -4,6 +4,10 @@ on:
     paths: 
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,10 @@ on:
   - push
   - pull_request
   - workflow_call
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
Setting token permissions to read-only follows the principle of least privilege. This is important because attackers may use a compromised token with write access to push malicious code into the project. [More info](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)

This will increase our CLOMonitor score

Fix https://github.com/kubewarden/kwctl/issues/341