### PR TITLE
Add permission at the job level

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-# Declare default permissions as read only.
-permissions: read-all
-
 jobs:
   ci:
     # A branch is required, and cannot be dynamic - https://github.com/actions/runner/issues/1493
     uses: kubewarden/kwctl/.github/workflows/tests.yml@main
+    permissions: read-all
 
   build-linux-binaries:
     name: Build linux binary
@@ -247,6 +245,8 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs:
       - build-linux-binaries
       - build-darwin-binaries


### PR DESCRIPTION
Build image gh action was broken when we introduced permissions: read-all at the top level of all files. 
This PR sets the permissions at job level instead, which fixes the issue. This should also be ok with CLOMonitor. We won't get the maximun score for the token permission (10) but it should give us more than 4 that is required for the check to be green. [More info](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
Everything worked fine when I created a release in my fork with [this changes](https://github.com/raulcabello/kwctl/actions/runs/3384521485)