### PR TITLE
chore: Add CLOMonitor exemption for `artifacthub_badge`

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,7 @@
+# CLOMonitor metadata file
+# This file must be located at the root of the repository
+
+# Checks exemptions
+exemptions:
+  - check: artifacthub_badge # Check identifier (see https://github.com/cncf/clomonitor/blob/main/docs/checks.md#exemptions)
+    reason: "kwctl is a cli binary, can't be published in ArtifactHub" # Justification of this exemption (mandatory, it will be displayed on the UI)


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Add CLOMonitor exemption for `artifacthub_bagde`, `kwctl` is a cli binary and can't be published there.

See https://clomonitor.io/docs/topics/checks/#exemptions

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

