### PR TITLE
save and load commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "burrego"
 version = "0.2.0"
-source = "git+https://github.com/raulcabello/policy-evaluator?branch=policy_prefix#39fd3c97dac11fb7d71cf754bfb3d52d503db0c2"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.13#a78c75e477f7561bc9978cc2c6e4acb7bc735ecb"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3268,8 +3268,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.4.12"
-source = "git+https://github.com/raulcabello/policy-evaluator?branch=policy_prefix#39fd3c97dac11fb7d71cf754bfb3d52d503db0c2"
+version = "0.4.13"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.13#a78c75e477f7561bc9978cc2c6e4acb7bc735ecb"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3296,8 +3296,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.7.13"
-source = "git+https://github.com/raulcabello/policy-fetcher?branch=policy_prefix#ce574e4ade9c9bc7951a48d68df2e63db13c1821"
+version = "0.7.14"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.7.14#2931a347f5007284bd7c37ec91143994be67927e"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "burrego"
 version = "0.2.0"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.12#d1cd00631296027ee2e000725158b95898770e9e"
+source = "git+https://github.com/raulcabello/policy-evaluator?branch=policy_prefix#39fd3c97dac11fb7d71cf754bfb3d52d503db0c2"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc529705a6e0028189c83f0a5dd9fb214105116f7e3c0eeab7ff0369766b0d1"
+checksum = "a87b30366b6766751277791b473b674f3bf7fb75696841c784a3eb7e7fbf44ee"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -1456,6 +1456,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,9 +2234,9 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "kube"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
+checksum = "fcf241a3a42bca4a2d1c21f2f34a659655032a7858270c7791ad4433aa8d79cb"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2233,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
+checksum = "7e442b4e6d55c4b3d0c0c70d79a8865bf17e2c33725f9404bfcb8a29ee002ffe"
 dependencies = [
  "base64 0.13.1",
  "bytes",
@@ -2269,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
+checksum = "eca2e1b1528287ba61602bbd17d0aa717fbb4d0fb257f4fa3a5fa884116ef778"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2320,6 +2332,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "directories",
+ "flate2",
  "itertools",
  "k8s-openapi",
  "lazy_static",
@@ -2334,6 +2347,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.14",
  "syntect",
+ "tar",
  "tempfile",
  "tokio",
  "tracing",
@@ -3255,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "policy-evaluator"
 version = "0.4.12"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.12#d1cd00631296027ee2e000725158b95898770e9e"
+source = "git+https://github.com/raulcabello/policy-evaluator?branch=policy_prefix#39fd3c97dac11fb7d71cf754bfb3d52d503db0c2"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3283,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "policy-fetcher"
 version = "0.7.13"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.7.13#1343ae076a9f816314d49eee2c0f1b590b0c47bd"
+source = "git+https://github.com/raulcabello/policy-fetcher?branch=policy_prefix#ce574e4ade9c9bc7951a48d68df2e63db13c1821"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4301,6 +4315,17 @@ dependencies = [
  "rustix",
  "windows-sys 0.36.1",
  "winx",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5606,6 +5631,15 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time 0.3.17",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ itertools = "0.10.5"
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_25"] }
 lazy_static = "1.4.0"
 mdcat = "0.29"
-#TODO change this once PR gets merged
-policy-evaluator = { git = "https://github.com/raulcabello/policy-evaluator", branch = "policy_prefix" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.13" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.9"
 pulldown-cmark = { version = "0.9.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ itertools = "0.10.5"
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_25"] }
 lazy_static = "1.4.0"
 mdcat = "0.29"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.12" }
+#TODO change this once PR gets merged
+policy-evaluator = { git = "https://github.com/raulcabello/policy-evaluator", branch = "policy_prefix" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.9"
 pulldown-cmark = { version = "0.9.2", default-features = false }
@@ -34,6 +35,8 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 url = "2.3.1"
 walrus = "0.19.0"
 wasmparser = "0.93"
+flate2 = "1.0.24"
+tar = "0.4.38"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/e2e-tests/e2e.bats
+++ b/e2e-tests/e2e.bats
@@ -104,21 +104,21 @@ kwctl() {
 }
 
 @test "save and load" {
-    kwctl pull registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9
+    kwctl pull registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     kwctl pull https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm
     kwctl policies
     [[ $(echo "$output" | wc -l) -eq 6 ]]
-    [[ "$output" =~ "registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9" ]]
+    [[ "$output" =~ "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9" ]]
     [[ "$output" =~ "https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm" ]]
-    kwctl save --output policies.tar.gz registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9 https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm
-    kwctl rm registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9
+    kwctl save --output policies.tar.gz registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9 https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm
+    kwctl rm registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     kwctl rm https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm
     kwctl policies
     [ "$output" = "" ]
     kwctl load --input policies.tar.gz
     kwctl policies
     [[ $(echo "$output" | wc -l) -eq 6 ]]
-    [[ "$output" =~ "registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9" ]]
+    [[ "$output" =~ "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9" ]]
     [[ "$output" =~ "https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm" ]]
     rm policies.tar.gz
 }

--- a/e2e-tests/e2e.bats
+++ b/e2e-tests/e2e.bats
@@ -102,3 +102,23 @@ kwctl() {
     [ "$status" -ne 0 ]
     [[ "$output" == "Error: Wrong value inside of policy's metatada for 'executionMode'. This policy has been created using Rego" ]]
 }
+
+@test "save and load" {
+    kwctl pull registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9
+    kwctl pull https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm
+    kwctl policies
+    [[ $(echo "$output" | wc -l) -eq 6 ]]
+    [[ "$output" =~ "registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9" ]]
+    [[ "$output" =~ "https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm" ]]
+    kwctl save --output policies.tar.gz registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9 https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm
+    kwctl rm registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9
+    kwctl rm https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm
+    kwctl policies
+    [ "$output" = "" ]
+    kwctl load --input policies.tar.gz
+    kwctl policies
+    [[ $(echo "$output" | wc -l) -eq 6 ]]
+    [[ "$output" =~ "registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9" ]]
+    [[ "$output" =~ "https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm" ]]
+    rm policies.tar.gz
+}

--- a/e2e-tests/e2e.bats
+++ b/e2e-tests/e2e.bats
@@ -106,6 +106,8 @@ kwctl() {
 @test "save and load" {
     kwctl pull registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     kwctl pull https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm
+    export privileged_registry_sha=$(sha256sum $XDG_CACHE_HOME/kubewarden/store/registry/ghcr.io/kubewarden/tests/pod-privileged:v0.1.9)
+    export privileged_https_sha=$(sha256sum $XDG_CACHE_HOME/kubewarden/store/https/github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm)
     kwctl policies
     [[ $(echo "$output" | wc -l) -eq 6 ]]
     [[ "$output" =~ "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9" ]]
@@ -120,5 +122,7 @@ kwctl() {
     [[ $(echo "$output" | wc -l) -eq 6 ]]
     [[ "$output" =~ "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9" ]]
     [[ "$output" =~ "https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm" ]]
+    [[ "$privileged_registry_sha" = $(sha256sum $XDG_CACHE_HOME/kubewarden/store/registry/ghcr.io/kubewarden/tests/pod-privileged:v0.1.9) ]]
+    [[ "$privileged_https_sha" = $(sha256sum $XDG_CACHE_HOME/kubewarden/store/https/github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm) ]]
     rm policies.tar.gz
-}
+ }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -527,6 +527,35 @@ pub fn build_cli() -> Command {
                         .help("Path to a Docker config.json-like path. Can be used to indicate registry authentication details")
                 )
         )
+        .subcommand(
+            Command::new("save")
+                .about("save policies in tar file")
+                .arg(
+                    Arg::new("policies")
+                        .num_args(1..)
+                        .required(true)
+                        .help("list of policies to save")
+                )
+                .arg(
+                    Arg::new("output")
+                    .long("output")
+                    .short('o')
+                    .required(true)
+                    .value_name("PATH")
+                    .help("path where the file will be stored")
+                )
+
+        )
+        .subcommand(
+            Command::new("load")
+                .about("load policies from tar file")
+                .arg(
+                    Arg::new("input")
+                        .long("input")
+                        .required(true)
+                        .help("load policies from tarball")
+                )
+        )
         .long_version(VERSION_AND_BUILTINS.as_str())
         .subcommand_required(true)
         .arg_required_else_help(true)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -529,7 +529,7 @@ pub fn build_cli() -> Command {
         )
         .subcommand(
             Command::new("save")
-                .about("save policies in tar file")
+                .about("save policies in tar.gz file")
                 .arg(
                     Arg::new("policies")
                         .num_args(1..)
@@ -548,7 +548,7 @@ pub fn build_cli() -> Command {
         )
         .subcommand(
             Command::new("load")
-                .about("load policies from tar file")
+                .about("load policies from a tar.gz file")
                 .arg(
                     Arg::new("input")
                         .long("input")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -529,7 +529,7 @@ pub fn build_cli() -> Command {
         )
         .subcommand(
             Command::new("save")
-                .about("save policies in tar.gz file")
+                .about("save policies to a tar.gz file")
                 .arg(
                     Arg::new("policies")
                         .num_args(1..)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -541,7 +541,7 @@ pub fn build_cli() -> Command {
                     .long("output")
                     .short('o')
                     .required(true)
-                    .value_name("PATH")
+                    .value_name("FILE")
                     .help("path where the file will be stored")
                 )
 

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+use flate2::read::GzDecoder;
+use policy_evaluator::policy_fetcher::store::Store;
+use std::fs::File;
+use tar::Archive;
+
+// load policies inside the tarball provided by source_path into the default store
+pub(crate) fn load(source_path: String) -> Result<()> {
+    let default_store = Store::default();
+    let destination_path = default_store.root;
+    let tar_gz = File::open(source_path)?;
+    let tar = GzDecoder::new(tar_gz);
+    let mut archive = Archive::new(tar);
+    archive.unpack(destination_path)?;
+
+    Ok(())
+}

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use flate2::read::GzDecoder;
 use policy_evaluator::policy_fetcher::store::Store;
 use std::fs::File;
@@ -8,10 +8,10 @@ use tar::Archive;
 pub(crate) fn load(source_path: &str) -> Result<()> {
     let default_store = Store::default();
     let destination_path = default_store.root;
-    let tar_gz = File::open(source_path)?;
+    let tar_gz = File::open(source_path).map_err(|e| anyhow!("cannot open file {}: {}", source_path, e))?;
     let tar = GzDecoder::new(tar_gz);
     let mut archive = Archive::new(tar);
-    archive.unpack(destination_path)?;
+    archive.unpack(destination_path).map_err(|e| anyhow!("cannot unpack file {}: {}", source_path, e))?;
 
     Ok(())
 }

--- a/src/load.rs
+++ b/src/load.rs
@@ -8,10 +8,13 @@ use tar::Archive;
 pub(crate) fn load(source_path: &str) -> Result<()> {
     let default_store = Store::default();
     let destination_path = default_store.root;
-    let tar_gz = File::open(source_path).map_err(|e| anyhow!("cannot open file {}: {}", source_path, e))?;
+    let tar_gz =
+        File::open(source_path).map_err(|e| anyhow!("cannot open file {}: {}", source_path, e))?;
     let tar = GzDecoder::new(tar_gz);
     let mut archive = Archive::new(tar);
-    archive.unpack(destination_path).map_err(|e| anyhow!("cannot unpack file {}: {}", source_path, e))?;
+    archive
+        .unpack(destination_path)
+        .map_err(|e| anyhow!("cannot unpack file {}: {}", source_path, e))?;
 
     Ok(())
 }

--- a/src/load.rs
+++ b/src/load.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use tar::Archive;
 
 // load policies inside the tarball provided by source_path into the default store
-pub(crate) fn load(source_path: String) -> Result<()> {
+pub(crate) fn load(source_path: &str) -> Result<()> {
     let default_store = Store::default();
     let destination_path = default_store.root;
     let tar_gz = File::open(source_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,7 +391,7 @@ async fn main() -> Result<()> {
         Some("load") => {
             if let Some(matches) = matches.subcommand_matches("load") {
                 let input = matches.get_one::<String>("input").unwrap();
-                load(input.to_string())?;
+                load(input)?;
             }
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ extern crate serde_yaml;
 
 use anyhow::{anyhow, Result};
 use clap::ArgMatches;
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use std::{
     collections::HashMap,
@@ -29,6 +30,8 @@ use tracing_subscriber::{
     fmt,
 };
 
+use crate::load::load;
+use crate::save::save;
 use policy_evaluator::policy_evaluator::PolicyExecutionMode;
 use policy_evaluator::policy_fetcher::{
     registry::Registry,
@@ -49,11 +52,13 @@ mod backend;
 mod cli;
 mod completions;
 mod inspect;
+mod load;
 mod policies;
 mod pull;
 mod push;
 mod rm;
 mod run;
+mod save;
 mod scaffold;
 mod utils;
 mod verify;
@@ -371,6 +376,22 @@ async fn main() -> Result<()> {
                 let registry = Registry::new();
                 let digest = registry.manifest_digest(uri, sources.as_ref()).await?;
                 println!("{}@{}", uri, digest);
+            }
+            Ok(())
+        }
+        Some("save") => {
+            if let Some(matches) = matches.subcommand_matches("save") {
+                let policies = matches.get_many::<String>("policies").unwrap();
+                let output = matches.get_one::<String>("output").unwrap();
+
+                save(policies.collect_vec(), output)?;
+            }
+            Ok(())
+        }
+        Some("load") => {
+            if let Some(matches) = matches.subcommand_matches("load") {
+                let input = matches.get_one::<String>("input").unwrap();
+                load(input.to_string())?;
             }
             Ok(())
         }

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use policy_evaluator::policy_fetcher::store::{PolicyPath, Store};
@@ -6,17 +6,17 @@ use std::fs::File;
 
 // saves all policies in a tarball with the name provided as output.
 // policies must be inside the default store.
-pub(crate) fn save(images: Vec<&String>, output: &str) -> Result<()> {
-    let tar_gz = File::create(output)?;
+pub(crate) fn save(policies: Vec<&String>, output: &str) -> Result<()> {
+    let tar_gz = File::create(output).map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
     let enc = GzEncoder::new(tar_gz, Compression::default());
     let mut tar = tar::Builder::new(enc);
 
-    for image in images {
+    for policy in policies {
         let store = Store::default();
-        let wasm_path = crate::utils::wasm_path(image.as_str())?;
-        let mut file = File::open(wasm_path)?;
-        let policy_path = store.policy_path(image, PolicyPath::PrefixAndFilename)?;
-        tar.append_file(policy_path, &mut file)?;
+        let wasm_path = crate::utils::wasm_path(policy.as_str()).map_err(|e| anyhow!("cannot find policy {}: {}", policy, e))?;
+        let mut file = File::open(wasm_path).map_err(|e| anyhow!("cannot open policy file {}: {}", policy, e))?;
+        let policy_path = store.policy_path(policy, PolicyPath::PrefixAndFilename).map_err(|e| anyhow!("cannot find path for policy {}: {}", policy, e))?;
+        tar.append_file(policy_path, &mut file).map_err(|e| anyhow!("cannot append policy {} to tar file: {}", policy, e))?;
     }
 
     Ok(())

--- a/src/save.rs
+++ b/src/save.rs
@@ -7,16 +7,22 @@ use std::fs::File;
 // saves all policies in a tarball with the name provided as output.
 // policies must be inside the default store.
 pub(crate) fn save(policies: Vec<&String>, output: &str) -> Result<()> {
-    let tar_gz = File::create(output).map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
+    let tar_gz =
+        File::create(output).map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
     let enc = GzEncoder::new(tar_gz, Compression::default());
     let mut tar = tar::Builder::new(enc);
 
     for policy in policies {
         let store = Store::default();
-        let wasm_path = crate::utils::wasm_path(policy.as_str()).map_err(|e| anyhow!("cannot find policy {}: {}", policy, e))?;
-        let mut file = File::open(wasm_path).map_err(|e| anyhow!("cannot open policy file {}: {}", policy, e))?;
-        let policy_path = store.policy_path(policy, PolicyPath::PrefixAndFilename).map_err(|e| anyhow!("cannot find path for policy {}: {}", policy, e))?;
-        tar.append_file(policy_path, &mut file).map_err(|e| anyhow!("cannot append policy {} to tar file: {}", policy, e))?;
+        let wasm_path = crate::utils::wasm_path(policy.as_str())
+            .map_err(|e| anyhow!("cannot find policy {}: {}", policy, e))?;
+        let mut file = File::open(wasm_path)
+            .map_err(|e| anyhow!("cannot open policy file {}: {}", policy, e))?;
+        let policy_path = store
+            .policy_path(policy, PolicyPath::PrefixAndFilename)
+            .map_err(|e| anyhow!("cannot find path for policy {}: {}", policy, e))?;
+        tar.append_file(policy_path, &mut file)
+            .map_err(|e| anyhow!("cannot append policy {} to tar file: {}", policy, e))?;
     }
 
     Ok(())

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use policy_evaluator::policy_fetcher::store::{PolicyPath, Store};
+use std::fs::File;
+
+// saves all policies in a tarball with the name provided as output.
+// policies must be inside the default store.
+pub(crate) fn save(images: Vec<&String>, output: &str) -> Result<()> {
+    let tar_gz = File::create(output)?;
+    let enc = GzEncoder::new(tar_gz, Compression::default());
+    let mut tar = tar::Builder::new(enc);
+
+    for image in images {
+        let store = Store::default();
+        let wasm_path = crate::utils::wasm_path(image.as_str())?;
+        let mut file = File::open(wasm_path)?;
+        let policy_path = store.policy_path(image, PolicyPath::PrefixAndFilename)?;
+        tar.append_file(policy_path, &mut file)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
There are two new commands in this PR:

- `save`: stores the provided policies into a tarball
- `load`: load the policies in the tarball into the default store

This is needed for airgap support. Policies will be stored into a tarball, then this tarball is moved to the airgapped environment. Finally, `kwctl load` is used to import the policies in the airgapped environment.

Fix #346 
