### PR TITLE
Release 1.4.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,71 @@
 ## [Unreleased]
 
 
+<a name="v1.4.0-rc1"></a>
+## [v1.4.0-rc1] - 2022-12-01
+### Bug Fixes
+- ensure e2e tests are not using public policies
+- shellchecks errors in airgap scripts
+- **deps:** update rust crate flate2 to 1.0.25
+
+### Code Refactoring
+- cleanup the `pull_and_run` API
+- use tests policies in e2e test
+- move shift out of switch block
+- move airga scripts to scripst folder
+
+### Features
+- implement the "bench" command
+- support certificate based verification
+- add airgap scripts to releases
+- add shellcheck to github action
+- kubewarden-load-policies.sh
+- kubewarden-save-policies.sh
+
+### Pull Requests
+- Merge pull request [#371](https://github.com/kubewarden/kwctl/issues/371) from kubewarden/dependabot/cargo/policy-evaluator-v0.4.16
+- Merge pull request [#369](https://github.com/kubewarden/kwctl/issues/369) from kubewarden/renovate/all-patch
+- Merge pull request [#372](https://github.com/kubewarden/kwctl/issues/372) from kubewarden/dependabot/cargo/mdcat-0.30.1
+- Merge pull request [#370](https://github.com/kubewarden/kwctl/issues/370) from kubewarden/dependabot/cargo/rstest-0.16.0
+- Merge pull request [#368](https://github.com/kubewarden/kwctl/issues/368) from flavio/add-bench-command
+- Merge pull request [#367](https://github.com/kubewarden/kwctl/issues/367) from flavio/sigstore-cert-verification
+- Merge pull request [#357](https://github.com/kubewarden/kwctl/issues/357) from kubewarden/renovate/lock-file-maintenance
+- Merge pull request [#364](https://github.com/kubewarden/kwctl/issues/364) from raulcabello/scripts
+- Merge pull request [#359](https://github.com/kubewarden/kwctl/issues/359) from kubewarden/dependabot/cargo/wasmparser-0.95.0
+- Merge pull request [#358](https://github.com/kubewarden/kwctl/issues/358) from kubewarden/dependabot/cargo/tokio-1.22.0
+- Merge pull request [#354](https://github.com/kubewarden/kwctl/issues/354) from raulcabello/save-load-script
+
+
+<a name="v1.3.1"></a>
+## [v1.3.1] - 2022-11-15
+### Code Refactoring
+- add more description to save/load errors
+- change source_path var to &str
+- change save output arg value_name to FILE
+
+### Features
+- add save and load commands
+- Support metadata.backgroundAudit
+
+### Pull Requests
+- Merge pull request [#355](https://github.com/kubewarden/kwctl/issues/355) from raulcabello/bump-evaluator
+- Merge pull request [#352](https://github.com/kubewarden/kwctl/issues/352) from kubewarden/renovate/lock-file-maintenance
+- Merge pull request [#349](https://github.com/kubewarden/kwctl/issues/349) from kubewarden/dependabot/cargo/wasmparser-0.94.0
+- Merge pull request [#348](https://github.com/kubewarden/kwctl/issues/348) from raulcabello/save
+- Merge pull request [#347](https://github.com/kubewarden/kwctl/issues/347) from viccuad/clomonitor-exemptions
+- Merge pull request [#345](https://github.com/kubewarden/kwctl/issues/345) from kubewarden/renovate/lock-file-maintenance
+- Merge pull request [#344](https://github.com/kubewarden/kwctl/issues/344) from raulcabello/ghaction-fix
+- Merge pull request [#342](https://github.com/kubewarden/kwctl/issues/342) from kubewarden/renovate/lock-file-maintenance
+- Merge pull request [#339](https://github.com/kubewarden/kwctl/issues/339) from viccuad/feat-audit
+
+
 <a name="v1.3.0"></a>
 ## [v1.3.0] - 2022-10-27
 ### Bug Fixes
 - update cosign version used by GH actions
 
 ### Pull Requests
+- Merge pull request [#340](https://github.com/kubewarden/kwctl/issues/340) from flavio/v1.3.0
 - Merge pull request [#336](https://github.com/kubewarden/kwctl/issues/336) from kubewarden/dependabot/cargo/wasmparser-0.93.0
 
 
@@ -15,6 +74,9 @@
 ## [v1.3.0-rc3] - 2022-10-26
 ### Bug Fixes
 - **deps:** update rust crate serde_yaml to 0.9.14
+- **deps:** update all patchlevel dependencies
+- **deps:** update rust crate serde_yaml to 0.9.11
+- **deps:** update rust crate serde_yaml to 0.9.10
 
 ### Pull Requests
 - Merge pull request [#338](https://github.com/kubewarden/kwctl/issues/338) from flavio/1.3.0-rc3
@@ -23,16 +85,6 @@
 - Merge pull request [#333](https://github.com/kubewarden/kwctl/issues/333) from kubewarden/renovate/all-patch
 - Merge pull request [#334](https://github.com/kubewarden/kwctl/issues/334) from kubewarden/renovate/lock-file-maintenance
 - Merge pull request [#329](https://github.com/kubewarden/kwctl/issues/329) from flavio/v1.3.0-rc1
-
-
-<a name="v1.3.0-rc1"></a>
-## [v1.3.0-rc1] - 2022-10-21
-### Bug Fixes
-- **deps:** update all patchlevel dependencies
-- **deps:** update rust crate serde_yaml to 0.9.11
-- **deps:** update rust crate serde_yaml to 0.9.10
-
-### Pull Requests
 - Merge pull request [#328](https://github.com/kubewarden/kwctl/issues/328) from flavio/update-deps
 - Merge pull request [#315](https://github.com/kubewarden/kwctl/issues/315) from kubewarden/renovate/lock-file-maintenance
 - Merge pull request [#300](https://github.com/kubewarden/kwctl/issues/300) from kubewarden/renovate/all-patch
@@ -472,10 +524,11 @@
 - Merge pull request [#12](https://github.com/kubewarden/kwctl/issues/12) from ereslibre/drop-uri-named-arg
 
 
-[Unreleased]: https://github.com/kubewarden/kwctl/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/kubewarden/kwctl/compare/v1.4.0-rc1...HEAD
+[v1.4.0-rc1]: https://github.com/kubewarden/kwctl/compare/v1.3.1...v1.4.0-rc1
+[v1.3.1]: https://github.com/kubewarden/kwctl/compare/v1.3.0...v1.3.1
 [v1.3.0]: https://github.com/kubewarden/kwctl/compare/v1.3.0-rc3...v1.3.0
-[v1.3.0-rc3]: https://github.com/kubewarden/kwctl/compare/v1.3.0-rc1...v1.3.0-rc3
-[v1.3.0-rc1]: https://github.com/kubewarden/kwctl/compare/v1.1.3...v1.3.0-rc1
+[v1.3.0-rc3]: https://github.com/kubewarden/kwctl/compare/v1.1.3...v1.3.0-rc3
 [v1.1.3]: https://github.com/kubewarden/kwctl/compare/v1.1.2...v1.1.3
 [v1.1.2]: https://github.com/kubewarden/kwctl/compare/v1.1.1...v1.1.2
 [v1.1.1]: https://github.com/kubewarden/kwctl/compare/v1.1.0...v1.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "burrego"
 version = "0.2.0"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.16#78d8ce0e2311804ecdce2ed0408fb0d279c567ef"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.17#829363dfd99da82ec5ef55c4be6ccbd0548f3ecd"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2327,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e164eef7c4defa524673223cac3c51644f16b3f09167fa6dd5a6f0dcc1185ff"
+checksum = "53e35080e4c03d52b6fba0d230f831651088c30d955167cd2062d82b586f4fb6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3308,8 +3308,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.4.16"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.16#78d8ce0e2311804ecdce2ed0408fb0d279c567ef"
+version = "0.4.17"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.17#829363dfd99da82ec5ef55c4be6ccbd0548f3ecd"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.3.1"
+version = "1.4.0-rc1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ itertools = "0.10.5"
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_25"] }
 lazy_static = "1.4.0"
 mdcat = "0.30"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.16" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.17" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.9"
 pulldown-cmark = { version = "0.9.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.3.1"
+version = "1.4.0-rc1"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]


### PR DESCRIPTION
## Description

Release `1.4.0-rc1`.

This is a minor Kubewarden version (policy-server, charts, etc will follow). This version supports verifying Sigstore signatures done using x509 certificates and their certificate chains.

## Test

Tested by manually using this unreleased `kwctl 1.4.0-rc1` to run the e2e tests of verify-image-signatures-policy.

## Additional Information

To be tagged  `1.4.0-rc1` once it lands in main.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
