### PR TITLE
bench do not write results to disk by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -558,6 +558,12 @@ pub fn build_cli() -> Command {
                     .value_name("SECONDS")
                     .help("How long the bench should warm up")
                 )
+                .arg(
+                    Arg::new("dump_results_to_disk")
+                    .long("dump-results-to-disk")
+                    .help("Puts results in target/tiny-bench/label/.. if target can be found. used for comparing previous runs")
+                )
+
                 // The next ones are exactly like the `run` args
                 .arg(
                     Arg::new("docker-config-json-path")

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,6 +250,7 @@ async fn main() -> Result<()> {
                     })?;
                     benchmark_cfg.warm_up_time = Duration::from_secs(duration);
                 }
+                benchmark_cfg.dump_results_to_disk = matches.contains_id("dump_results_to_disk");
 
                 bench::pull_and_bench(&bench::PullAndBenchSettings {
                     pull_and_run_settings,


### PR DESCRIPTION
The bench command should not attempt to write the benchmarks results to disk by default.
The crate we're using has a hard-coded path which exists only when inside of a Rust project.

Prior to this commit, the following warning messages (shown in red) were printed when the path was not found:

```console
Failed to read last sample, cause Could not find target directory to place output
Failed to write sampling data, cause: Could not find target directory to place output
```

This can mislead/scare end users.

This commit disables this behavior and introduces a new flag that can be used to write the results back to disk.

