### PR TITLE
chore: update to latest policy-evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
 name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,10 +427,10 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "burrego"
 version = "0.2.0"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.17#829363dfd99da82ec5ef55c4be6ccbd0548f3ecd"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.5.0#1660628eaaba8990d084395bdcfeee972b2fd777"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.20.0",
  "chrono",
  "chrono-tz",
  "gtmpl",
@@ -2189,12 +2195,13 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
+checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror",
  "treediff",
 ]
 
@@ -2312,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e35080e4c03d52b6fba0d230f831651088c30d955167cd2062d82b586f4fb6"
+checksum = "0b69ffd390861100ac05c08aacea43d10e6c2541b0d3e858fa7d7231de06d244"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2432,9 +2439,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -2776,10 +2783,11 @@ dependencies = [
 
 [[package]]
 name = "oci-distribution"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fa0963c4a3870267e3455c7f15340f3c5d7d1080d417696e86d5d260bee0a7"
+checksum = "2ac5b780ce1bd6c3c2ff72a3013f4b2d56d53ae03b20d424e99d2f6556125138"
 dependencies = [
+ "futures",
  "futures-util",
  "http",
  "http-auth",
@@ -2793,6 +2801,7 @@ dependencies = [
  "sha2 0.10.6",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "unicase",
 ]
@@ -2808,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4bda43fd1b844cbc6e6e54b5444e2b1bc7838bce59ad205902cccbb26d6761"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
  "asn1-rs",
 ]
@@ -2935,7 +2944,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -2950,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if",
  "instant",
@@ -2997,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
 
 [[package]]
 name = "path-absolutize"
@@ -3294,11 +3303,11 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.4.17"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.17#829363dfd99da82ec5ef55c4be6ccbd0548f3ecd"
+version = "0.5.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.5.0#1660628eaaba8990d084395bdcfeee972b2fd777"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.20.0",
  "burrego",
  "cached",
  "chrono",
@@ -3320,20 +3329,20 @@ dependencies = [
  "url",
  "validator",
  "wapc",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmtime-provider",
 ]
 
 [[package]]
 name = "policy-fetcher"
-version = "0.7.16"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.7.16#3f97e38a5c25422daf7c62614480f9881db6fc46"
+version = "0.7.17"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.7.17#b9f917bde0cae115260a19aabeab286afc02891a"
 dependencies = [
  "anyhow",
  "async-std",
  "async-stream",
  "async-trait",
- "base64 0.13.1",
+ "base64 0.20.0",
  "directories",
  "docker_credential",
  "lazy_static",
@@ -3356,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
+checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -3775,7 +3784,7 @@ dependencies = [
  "errno",
  "io-lifetimes 1.0.3",
  "libc",
- "linux-raw-sys 0.1.3",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.42.0",
 ]
 
@@ -4591,6 +4600,7 @@ checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4599,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -4757,9 +4767,9 @@ dependencies = [
 
 [[package]]
 name = "treediff"
-version = "3.0.2"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
+checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ itertools = "0.10.5"
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_25"] }
 lazy_static = "1.4.0"
 mdcat = "0.30"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.17" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.5.0" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.9"
 pulldown-cmark = { version = "0.9.2", default-features = false }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use policy_evaluator::{
-    policy_evaluator::PolicyExecutionMode, policy_evaluator_builder::PolicyEvaluatorBuilder,
-    policy_metadata::Metadata, ProtocolVersion,
+    policy_evaluator::{Evaluator, PolicyExecutionMode},
+    policy_evaluator_builder::PolicyEvaluatorBuilder,
+    policy_metadata::Metadata,
+    ProtocolVersion,
 };
 use std::path::{Path, PathBuf};
 

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use policy_evaluator::policy_evaluator::ValidateRequest;
+use policy_evaluator::policy_evaluator::{Evaluator, ValidateRequest};
 use tiny_bench::{bench_with_configuration_labeled, BenchmarkConfig};
 use tracing::error;
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -4,7 +4,7 @@ use policy_evaluator::{
     cluster_context::ClusterContext,
     constants::*,
     kube::Client,
-    policy_evaluator::PolicyEvaluator,
+    policy_evaluator::{Evaluator, PolicyEvaluator},
     policy_evaluator::{PolicyExecutionMode, ValidateRequest},
     policy_evaluator_builder::PolicyEvaluatorBuilder,
     policy_fetcher::{sources::Sources, verify::FulcioAndRekorData, PullDestination},


### PR DESCRIPTION
Update to latest stable release and fix breakage caused by the API.
