### PR TITLE
Release v1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5167,16 +5167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a4460aa3e271fa180b6a5d003e728f3963fb30e3ba0fa7c9634caa06049328"
 dependencies = [
  "indexmap",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
-dependencies = [
- "indexmap",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.4.1"
+version = "1.4.2"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]


### PR DESCRIPTION
Changes:

- build(deps): bump wasmparser from 0.95.0 to 0.96.0 (#384)

- fix: use system certificates (#386)

- chore: update to latest policy-evaluator (#385)
- chore: update rust edition (#382)
- chore(deps): lock file maintenance (#381)
- build(deps): bump tokio from 1.22.0 to 1.23.0 (#380)

Signed-off-by: Flavio Castelli <fcastelli@suse.com>
