### PR TITLE
Upload airgap scripts as release assets.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,6 +296,7 @@ jobs:
             let fs = require('fs');
             let path = require('path');
             const patterns = [
+              `${DOWNLOAD_PATH}/kwctl-airgap-scripts/*`,
               `${DOWNLOAD_PATH}/kwctl-linux-*/*`,
               `${DOWNLOAD_PATH}/kwctl-darwin-*/*`,
               `${DOWNLOAD_PATH}/kwctl-windows-*/*`,


### PR DESCRIPTION
## Description

In the previous change adding the release drafter in the CI job, the step used to upload the assets to the release misses the airgap scripts. This commit fixes that adding the scripts in the list of file to be uploaded.

Fix #383 
