### PR TITLE
Run autolabeler when a PR is edited

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,10 +9,10 @@ on:
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
   # pull_request_target event is required for autolabeler to support PRs from forks
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Updates the CI release drafter job to be triggered when the a PR is edited. With that the autolabeler will run when the PR title is changed.