### PR TITLE
fix: report the right version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.4.2"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.4.2"
+version = "1.5.1"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]


### PR DESCRIPTION
We forgot to bump the version attribute inside of `Cargo.toml`.

This fixes https://github.com/kubewarden/kwctl/issues/409
