### PR TITLE
fix: scaffold should not generate the backgroundAudit field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4108,9 +4108,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
 dependencies = [
  "indexmap",
  "itoa 1.0.5",


### PR DESCRIPTION
Currently the `backgroundAudit` field is not known by the Kubewarden's stable CRDs.

Because of that, we should not generate this attribute at scaffold time.

This is a quick workaround for https://github.com/kubewarden/kubewarden-controller/issues/395

Note: the field is not scaffolded when it's `true`, which is the default case. A policy with `backgroundAudit` set to `false` would still cause the scaffold code to produce this field, leading to this bug again. However this is not a big deal, since no policy is currently setting this attribute. On the other hand, we need kwctl to generate this attribute for our development purposes.
