### PR TITLE
feat: Add `kwctl scaffold artifacthub` command, add `kwctl annotate --usage` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,6 +2556,7 @@ dependencies = [
  "syntect",
  "tar",
  "tempfile",
+ "time 0.3.20",
  "tiny-bench",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 [[package]]
 name = "burrego"
 version = "0.3.3"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.6.3#c417afdb38a96acbd9940b32c200164c1b689226"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.7.0#2a67a16862c7b0b4cfc697f9b1e6d25657bba366"
 dependencies = [
  "base64 0.21.0",
  "chrono",
@@ -853,28 +853,28 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc952b310b24444fc14ab8b9cbe3fafd7e7329e3eec84c3a9b11d2b5cf6f3be1"
+checksum = "2f3d54eab028f5805ae3b26fd60eca3f3a9cfb76b989d9bab173be3f61356cc3"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73470419b33011e50dbf0f6439cbccbaabe9381de172da4e1b6efcda4bb8fa7"
+checksum = "2be1d5f2c3cca1efb691844bc1988b89c77291f13f778499a3f3c0cf49c0ed61"
 dependencies = [
  "arrayvec",
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
- "cranelift-egraph",
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
+ "hashbrown 0.12.3",
  "log",
  "regalloc2",
  "smallvec",
@@ -883,47 +883,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a1872464108a11ac9965c2b079e61bbdf1bc2e0b9001264264add2e12a38f"
+checksum = "3f9b1b1089750ce4005893af7ee00bb08a2cf1c9779999c0f7164cbc8ad2e0d2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e036f3f07adb24a86fb46e977e8fe03b18bb16b1eada949cf2c48283e5f8a862"
-
-[[package]]
-name = "cranelift-egraph"
-version = "0.91.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6c623f4b5d2a6bad32c403f03765d4484a827eb93ee78f8cb6219ef118fd59"
-dependencies = [
- "cranelift-entity",
- "fxhash",
- "hashbrown 0.12.3",
- "indexmap",
- "log",
- "smallvec",
-]
+checksum = "cc5fbaec51de47297fd7304986fd53c8c0030abbe69728a60d72e1c63559318d"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74385eb5e405b3562f0caa7bcc4ab9a93c7958dd5bcd0e910bffb7765eacd6fc"
+checksum = "dab984c94593f876090fae92e984bdcc74d9b1acf740ab5f79036001c65cba13"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4ac920422ee36bff2c66257fec861765e3d95a125cdf58d8c0f3bba7e40e61"
+checksum = "6e0cb3102d21a2fe5f3210af608748ddd0cd09825ac12d42dc56ed5ed8725fe0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -933,15 +919,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c541263fb37ad2baa53ec8c37218ee5d02fa0984670d9419dedd8002ea68ff08"
+checksum = "72101dd1f441d629735143c41e00b3428f9267738176983ef588ff43382af0a0"
 
 [[package]]
 name = "cranelift-native"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de5d7a063e8563d670aaca38de16591a9b70dc66cbad4d49a7b4ae8395fd1ce"
+checksum = "c22b0d9fcbe3fc5a1af9e7021b44ce42b930bcefac446ce22e02e8f9a0d67120"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -950,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc4dd03b713b5d71b582915b8c272f4813cdd8c99a3e03d9ba70c44468a6e0"
+checksum = "bddebe32fb14fbfd9efa5f130ffb8f4665795de019928dcd7247b136c46f9249"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -960,7 +946,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmtime-types",
 ]
 
@@ -1384,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecdsa"
@@ -1450,6 +1436,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2333,9 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
@@ -2421,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.78.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ee2ba94546e32a5aef943e5831c6ac25592ff8dcfa8b2a06e0aaea90c69188"
+checksum = "414d80c69906a91e8ecf4ae16d0fb504e19aa6b099135d35d85298b4e4be3ed3"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2432,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.78.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9ca1f597bd48ed26f45f601bf2fa3aaa0933b8d1652d883b8444519b72af4a"
+checksum = "6dc5ae0b9148b4e2ebb0dabda06a0cd65b1eed2f41d792d49787841a68050283"
 dependencies = [
  "base64 0.20.0",
  "bytes",
@@ -2468,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.78.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f2c6d1a2d1584859499eb05a41c5a44713818041621fa7515cfdbdf4769ea7"
+checksum = "98331c6f1354893f7c50da069e43a3fd1c84e55bbedc7765d9db22ec3291d07d"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2546,7 +2541,7 @@ dependencies = [
  "policy-evaluator",
  "pretty-bytes",
  "prettytable-rs",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.2",
  "regex",
  "reqwest",
  "rstest",
@@ -2651,6 +2646,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mail-parser"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4158a1c18963244e083888b21465846dfb68d6170850ed1ab4742edd57c9d47"
+dependencies = [
+ "encoding_rs",
+ "serde",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,7 +2703,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "once_cell",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.2",
  "reqwest",
  "resvg",
  "shell-words",
@@ -3497,8 +3502,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.6.3"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.6.3#c417afdb38a96acbd9940b32c200164c1b689226"
+version = "0.7.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.7.0#2a67a16862c7b0b4cfc697f9b1e6d25657bba366"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -3506,24 +3511,30 @@ dependencies = [
  "cached 0.42.0",
  "chrono",
  "dns-lookup",
+ "email_address",
  "itertools",
  "json-patch",
  "k8s-openapi",
  "kube",
  "kubewarden-policy-sdk",
  "lazy_static",
+ "mail-parser",
  "picky",
  "policy-fetcher",
+ "semver",
  "serde",
  "serde_json",
+ "serde_yaml 0.9.17",
  "sha2 0.10.6",
+ "thiserror",
+ "time 0.3.20",
  "tokio",
  "tracing",
  "tracing-futures",
  "url",
  "validator",
  "wapc",
- "wasmparser 0.99.0",
+ "wasmparser 0.101.1",
  "wasmtime-provider",
 ]
 
@@ -3652,6 +3663,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -4198,6 +4220,9 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -5434,9 +5459,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79eba5cf83a4adb2ccba4c029858229a4992dd88cc35dbfa5a555ec7fc2a8416"
+checksum = "11254257c965082b671fb876e63a69c25af8d68b2b742d785593192b28df87a8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5458,9 +5483,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678ff55fb89ae721dae166003b843f53ee3e7bdb96aa96715fec8d44d012b105"
+checksum = "54c08c84016536b2407809253aa6c47eacf86d5b5ecd7741b50d23f18b5bb045"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -5571,19 +5596,9 @@ checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "wasmparser"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
-dependencies = [
- "indexmap",
- "url",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.99.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef3b717afc67f848f412d4f02c127dd3e35a0eecd58c684580414df4fde01d3"
+checksum = "adde01ade41ab9a5d10ec8ed0bb954238cf8625b5cd5a13093d6de2ad9c2be1a"
 dependencies = [
  "indexmap",
  "url",
@@ -5601,9 +5616,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abddf11816dd8f5e7310f6ebe5a2503b43f20ab2bf050b7d63f5b1bb96a81d9"
+checksum = "4e5b183a159484980138cc05231419c536d395a7b25c1802091310ea2f74276a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5619,8 +5634,9 @@ dependencies = [
  "rayon",
  "serde",
  "target-lexicon",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmtime-cache",
+ "wasmtime-component-macro",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -5632,18 +5648,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f5206486f0467ba86e84d35996c4048b077cec2c9e5b322e7b853bdbe79334"
+checksum = "c0aeb1cb256d76cf07b20264c808351c8b525ece56de1ef4d93f87a0aaf342db"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e77abcf538af42517e188c109e4b50ecf6c0ee4d77ede76a438e0306b934dc"
+checksum = "830570847f905b8f6d2ca635c33cf42ce701dd8e4abd7d1806c631f8f06e9e4b"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -5660,10 +5676,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-cranelift"
-version = "4.0.0"
+name = "wasmtime-component-macro"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5bcb1d5ef211726b11e1286fe96cb40c69044c3632e1d6c67805d88a2e1a34"
+checksum = "841561f7792cc46eea82dcf296393c5bab03259e663ff1bfccf71c2ae30e8920"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048583c2e765cac3e8842dd18a50d4feb3049ef3f182880db6626d6eb8a29383"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7695d3814dcb508bf4d1c181a86ea6b97a209f6444478e95d86e2ffab8d1a3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5676,15 +5712,15 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcab3fac5a2ff68ce9857166a7d7c0e5251b554839b9dda7ed3b5528e191936e"
+checksum = "e5a2a5f0fb93aa837a727a48dd1076e8a9f882cc2fee20b433c04a18740ff63b"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -5695,15 +5731,15 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "wasmtime-fiber"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb38af221b780f2c03764d763fe7f7bc414ea9db744d66dac98f9b694892561"
+checksum = "a00a5cbf3ee623d01edea8882eb4352a5370513c6c1942cc5cd56dd806293a8d"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5714,9 +5750,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d866e2a84ee164739b7ed7bd7cc9e1f918639d2ec5e2817a31e24c148cab20"
+checksum = "01c78f9fb2922dbb5a95f009539d4badb44866caeeb53d156bf2cf4d683c3afd"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5739,9 +5775,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0104c2b1ce443f2a2806216fcdf6dce09303203ec5797a698d313063b31e5bc8"
+checksum = "67cacdb52a77b8c8e744e510beeabf0bd698b1c94c59eed33c52b3fbd19639b0"
 dependencies = [
  "object",
  "once_cell",
@@ -5750,9 +5786,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "3.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d9c2e92b0fc124d2cad6cb497a4c840580a7dd2414a37109e8c7cfe699c0ea"
+checksum = "08fcba5ebd96da2a9f0747ab6337fe9788adfb3f63fa2c180520d665562d257e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5761,9 +5797,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-provider"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5befe45d15bcac147ed7d5113e6f67ccc8e3c49facdc15fa5b96ccf17e064e5"
+checksum = "ac61666f24689551fc2e69e4658096e1b14164a91460a80da7e1059a45e06e70"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5779,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1f0f99297a94cb20c511d1d4e864d9b54794644016d2530dc797cacfa7224a"
+checksum = "0793210acf50d4c69182c916abaee1d423dc5d172cdfde6acfea2f9446725940"
 dependencies = [
  "anyhow",
  "cc",
@@ -5804,27 +5840,38 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f3d8ee409447cae51651fd812437a0047ed8d7f44e94171ee05ce7cb955c96"
+checksum = "50d015ba8b231248a811e323cf7a525cd3f982d4be0b9e62d27685102e5f12b1"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f32b06e3282ccbeab6fb96c64fa12a359f1253022dfd5cf99385b2344e70830"
+checksum = "bd1271c6ec6585929986d059fc2e2365e7033e32ae3bc761ed4715fd47128308"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
  "wiggle",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51b1f66bc176d85b4bfa0c86731f270697f6e0e673878846c7f2971ab895652"
+dependencies = [
+ "anyhow",
+ "heck 0.4.1",
+ "wit-parser",
 ]
 
 [[package]]
@@ -5903,9 +5950,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2433252352677648dc4ac0c99e7e254e1c58be8019cda3323ab3a3ce29da5b"
+checksum = "63d256f306e99e90343029170d81154319a976292c35eba68b05792532fa365e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5918,9 +5965,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15bf89e66bd1a9463ee529d37b999947befafd792f345d4a82e0d2b28c0845f"
+checksum = "9a0e55a87dcb350634c9f9b3ec08bfc87d7b05a0303a5fe8bb3134452ba3b62f"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -5933,9 +5980,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919fb8f106375c7f6daf7b388a1fea3e2092dedb273b17b2d917522917c07a3c"
+checksum = "b70901617926a441dbb03f3d208bd02b3fffbda13cadd9b17e7cf9389d9c067e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6088,6 +6135,19 @@ dependencies = [
  "bitflags",
  "io-lifetimes",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703eb1d2f89ff2c52d50f7ff002735e423cea75f0a5dc5c8a4626c4c47cd9ca6"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "pulldown-cmark 0.8.0",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 # native-ssl. Using the rustls instead. Otherwise, the build will fail due the 
 # missing OpenSSL lib.
 mdcat = { version = "1.1", default-features = false, features = ["static"] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.6.3" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.7.0" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.9.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 url = "2.3.1"
 walrus = "0.19.0"
 wasmparser = "0.101"
+time = "0.3.17"
 
 # This is required to have reqwest built using the `rustls-tls-native-roots`
 # feature across all the transitive dependencies of kwctl

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -2,16 +2,26 @@ use crate::backend::{Backend, BackendDetector};
 use anyhow::{anyhow, Result};
 use policy_evaluator::validator::Validate;
 use policy_evaluator::{constants::*, policy_metadata::Metadata, ProtocolVersion};
-use std::fs::File;
+use std::fs::{self, File};
 use std::path::PathBuf;
 
 pub(crate) fn write_annotation(
     wasm_path: PathBuf,
     metadata_path: PathBuf,
     destination: PathBuf,
+    usage_path: Option<PathBuf>,
 ) -> Result<()> {
+    let usage_content: String;
+    let usage = match usage_path {
+        Some(path) => {
+            usage_content = fs::read_to_string(path)
+                .map_err(|e| anyhow!("Error reading questions file: {}", e))?;
+            Some(usage_content.as_str())
+        }
+        None => None,
+    };
     let backend_detector = BackendDetector::default();
-    let metadata = prepare_metadata(wasm_path.clone(), metadata_path, backend_detector)?;
+    let metadata = prepare_metadata(wasm_path.clone(), metadata_path, backend_detector, usage)?;
     write_annotated_wasm_file(wasm_path, destination, metadata)
 }
 
@@ -19,6 +29,7 @@ fn prepare_metadata(
     wasm_path: PathBuf,
     metadata_path: PathBuf,
     backend_detector: BackendDetector,
+    usage: Option<&str>,
 ) -> Result<Metadata> {
     let metadata_file =
         File::open(metadata_path).map_err(|e| anyhow!("Error opening metadata file: {}", e))?;
@@ -40,6 +51,12 @@ fn prepare_metadata(
         String::from(KUBEWARDEN_ANNOTATION_KWCTL_VERSION),
         String::from(env!("CARGO_PKG_VERSION")),
     );
+    if let Some(s) = usage {
+        annotations.insert(
+            String::from(KUBEWARDEN_ANNOTATION_POLICY_USAGE),
+            String::from(s),
+        );
+    }
     metadata.annotations = Some(annotations);
 
     metadata
@@ -119,6 +136,7 @@ mod tests {
             PathBuf::from("irrelevant.wasm"),
             file_path,
             backend_detector,
+            None,
         )?;
         let annotations = metadata.annotations.unwrap();
 
@@ -169,6 +187,7 @@ mod tests {
             PathBuf::from("irrelevant.wasm"),
             file_path,
             backend_detector,
+            None,
         )?;
         let annotations = metadata.annotations.unwrap();
 
@@ -215,12 +234,55 @@ mod tests {
             PathBuf::from("irrelevant.wasm"),
             file_path,
             backend_detector,
+            None,
         )?;
         let annotations = metadata.annotations.unwrap();
 
         assert_eq!(
             annotations.get(KUBEWARDEN_ANNOTATION_KWCTL_VERSION),
             Some(&String::from(env!("CARGO_PKG_VERSION"))),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_kwctl_usage_is_added_when_annotations_is_none() -> Result<()> {
+        let dir = tempdir()?;
+
+        let file_path = dir.path().join("metadata.yml");
+        let mut file = File::create(file_path.clone())?;
+
+        let raw_metadata = format!(
+            r#"
+        rules:
+        - apiGroups: [""]
+          apiVersions: ["v1"]
+          resources: ["pods"]
+          operations: ["CREATE", "UPDATE"]
+        mutating: false
+        backgroundAudit: true
+        executionMode: kubewarden-wapc
+        "#
+        );
+
+        write!(file, "{}", raw_metadata)?;
+
+        let backend_detector = BackendDetector::new(
+            mock_rego_policy_detector_false,
+            mock_protocol_version_detector_v1,
+        );
+        let metadata = prepare_metadata(
+            PathBuf::from("irrelevant.wasm"),
+            file_path,
+            backend_detector,
+            Some("readme contents"),
+        )?;
+        let annotations = metadata.annotations.unwrap();
+
+        assert_eq!(
+            annotations.get(KUBEWARDEN_ANNOTATION_POLICY_USAGE),
+            Some(&String::from("readme contents")),
         );
 
         Ok(())
@@ -256,6 +318,7 @@ mod tests {
             PathBuf::from("irrelevant.wasm"),
             file_path,
             backend_detector,
+            None,
         );
         assert!(metadata.is_ok());
         assert_eq!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -454,6 +454,34 @@ pub fn build_cli() -> Command {
                         .about("Output a default Sigstore verification configuration file")
                 )
                 .subcommand(
+                    Command::new("artifacthub")
+                        .about("Output an artifacthub-pkg.yml file from a metadata.yml file")
+                        .arg(
+                            Arg::new("metadata-path")
+                            .long("metadata-path")
+                            .short('m')
+                            .required(true)
+                            .value_name("PATH")
+                            .help("File containing the metadata of the policy")
+                        )
+                        .arg(
+                            Arg::new("version")
+                            .required(true)
+                            .long("version")
+                            .short('v')
+                            .number_of_values(1)
+                            .value_name("VALUE")
+                            .help("Semver version of the policy")
+                        )
+                        .arg(
+                            Arg::new("questions-path")
+                            .long("questions-path")
+                            .short('q')
+                            .value_name("PATH")
+                            .help("File containing the questions-ui content of the policy")
+                        )
+                )
+                .subcommand(
                     Command::new("manifest")
                         .about("Output a Kubernetes resource manifest")
                         .arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -401,6 +401,13 @@ pub fn build_cli() -> Command {
                     .help("File containing the metadata")
                 )
                 .arg(
+                    Arg::new("usage-path")
+                    .long("usage-path")
+                    .short('u')
+                    .value_name("PATH")
+                    .help("File containing the usage information of the policy")
+                )
+                .arg(
                     Arg::new("output-path")
                     .long("output-path")
                     .short('o')

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,10 @@ async fn main() -> Result<()> {
                     .get_one::<String>("output-path")
                     .map(|output| PathBuf::from_str(output).unwrap())
                     .unwrap();
-                annotate::write_annotation(wasm_path, metadata_file, destination)?;
+                let usage_file = matches
+                    .get_one::<String>("usage-path")
+                    .map(|output| PathBuf::from_str(output).unwrap());
+                annotate::write_annotation(wasm_path, metadata_file, destination, usage_file)?;
             }
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,6 +298,22 @@ async fn main() -> Result<()> {
                 }
             }
             if let Some(matches) = matches.subcommand_matches("scaffold") {
+                if let Some(artifacthub_matches) = matches.subcommand_matches("artifacthub") {
+                    let metadata_file = artifacthub_matches
+                        .get_one::<String>("metadata-path")
+                        .map(|output| PathBuf::from_str(output).unwrap())
+                        .unwrap();
+                    let version = artifacthub_matches.get_one::<String>("version").unwrap();
+                    let questions_file = artifacthub_matches
+                        .get_one::<String>("questions-path")
+                        .map(|output| PathBuf::from_str(output).unwrap());
+                    println!(
+                        "{}",
+                        scaffold::artifacthub(metadata_file, version, questions_file)?
+                    );
+                }
+            }
+            if let Some(matches) = matches.subcommand_matches("scaffold") {
                 if let Some(matches) = matches.subcommand_matches("manifest") {
                     let uri = matches.get_one::<String>("uri").unwrap();
                     let resource_type = matches.get_one::<String>("type").unwrap();

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -41,10 +41,10 @@ fn is_true(b: &bool) -> bool {
     *b
 }
 
-impl TryFrom<ScaffoldData> for ClusterAdmissionPolicy {
+impl TryFrom<ScaffoldPolicyData> for ClusterAdmissionPolicy {
     type Error = anyhow::Error;
 
-    fn try_from(data: ScaffoldData) -> Result<Self, Self::Error> {
+    fn try_from(data: ScaffoldPolicyData) -> Result<Self, Self::Error> {
         data.metadata.validate()?;
         Ok(ClusterAdmissionPolicy {
             api_version: String::from("policies.kubewarden.io/v1"),
@@ -86,10 +86,10 @@ struct AdmissionPolicySpec {
     background_audit: bool,
 }
 
-impl TryFrom<ScaffoldData> for AdmissionPolicy {
+impl TryFrom<ScaffoldPolicyData> for AdmissionPolicy {
     type Error = anyhow::Error;
 
-    fn try_from(data: ScaffoldData) -> Result<Self, Self::Error> {
+    fn try_from(data: ScaffoldPolicyData) -> Result<Self, Self::Error> {
         data.metadata.validate()?;
         Ok(AdmissionPolicy {
             api_version: String::from("policies.kubewarden.io/v1"),
@@ -110,7 +110,7 @@ impl TryFrom<ScaffoldData> for AdmissionPolicy {
 }
 
 #[derive(Clone)]
-struct ScaffoldData {
+struct ScaffoldPolicyData {
     pub uri: String,
     policy_title: Option<String>,
     metadata: Metadata,
@@ -134,7 +134,7 @@ pub(crate) fn manifest(
     let settings_yml: serde_yaml::Mapping =
         serde_yaml::from_str(&settings.unwrap_or_else(|| String::from("{}")))?;
 
-    let scaffold_data = ScaffoldData {
+    let scaffold_data = ScaffoldPolicyData {
         uri: String::from(uri),
         policy_title: get_policy_title_from_cli_or_metadata(policy_title, &metadata),
         metadata,
@@ -322,7 +322,7 @@ mod tests {
         metadata.protocol_version = Some(policy_evaluator::ProtocolVersion::V1);
         assert!(metadata.background_audit);
 
-        let scaffold_data = ScaffoldData {
+        let scaffold_data = ScaffoldPolicyData {
             uri: "not_relevant".to_string(),
             policy_title: get_policy_title_from_cli_or_metadata(Some(policy_title), &metadata),
             metadata,
@@ -352,7 +352,7 @@ mod tests {
         metadata.background_audit = false;
         assert!(!metadata.background_audit);
 
-        let scaffold_data = ScaffoldData {
+        let scaffold_data = ScaffoldPolicyData {
             uri: "not_relevant".to_string(),
             policy_title: get_policy_title_from_cli_or_metadata(Some(policy_title), &metadata),
             metadata,


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kwctl/issues/418
Depends on https://github.com/kubewarden/policy-evaluator/pull/246 

feat: Add `kwctl scaffold artifacthub` command 
feat: Add `--usage` flag to `kwctl annotate`
Depend on `time` crate.

Example:
```
kwctl scaffold artifacthub \
  --metadata-path metadata.yml \
  --version 0.2.1 \
  --questions-path questions-ui.yml > artifacthub-pkg.yml
```


## Test

Relevant `annotate` unit test has been added, artifacthub functionality is tested in policy-evaluator, and e2e tests are unnecessary.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

Right now `--version` is mandatory. 
