### PR TITLE
deps: Pin cosign to 1.* by pinning cosign-installer GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           # update the spec file to ensure that.
           sudo sed -i "s/-dynamic-linker.*/-no-dynamic-linker  -nostdlib %{shared:-shared} %{static:-static} %{rdynamic:-no-export-dynamic}/g" /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
 
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v2.8.1
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -136,7 +136,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v2.8.1
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -193,7 +193,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v2.8.1
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.5.0
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v2.8.1
         with:
           cosign-release: v1.13.1
       - name: run e2e tests


### PR DESCRIPTION
## Description

Cosign 2.0 was [released last week](https://blog.sigstore.dev/cosign-2-0-released/) (yay!) but, as expected because semver, it's not backwards compatible (nay!).

Pin cosign-installer GHA so it downloads cosign 1.*.
Latest [cosign-installer downloads cosign 2.*](https://github.com/sigstore/cosign-installer/releases/tag/v3.0.0).

## Test

Tested in my fork:
https://github.com/viccuad/kwctl/actions/runs/4315689467/jobs/7530608694 (that commit tag only had the linux build fixed there).

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
