### PR TITLE
fix: allow execution of e2e tests when k8s is not available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.6.0-rc3"
+version = "1.6.0-rc4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.6.0-rc3"
+version = "1.6.0-rc4"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]


### PR DESCRIPTION
When the host-capabilities replay mode is enabled, do not attempt to connect to Kubernetes.

This is needed to allow `kwctl run` to be used inside of environments where Kubernetes does not exist, such as running e2e tests inside of GitHub actions
