### PR TITLE
feat: --output flag to scaffold artifacthub command.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -413,6 +413,11 @@ fn subcommand_scaffold() -> Command {
             .short('q')
             .value_name("PATH")
             .help("File containing the questions-ui content of the policy"),
+        Arg::new("output")
+            .long("output")
+            .short('o')
+            .value_name("FILE")
+            .help("Path where the artifact-pkg.yml file will be stored"),
     ];
     artifacthub_args.sort_by(|a, b| a.get_id().cmp(b.get_id()));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,10 +317,13 @@ async fn main() -> Result<()> {
                     let questions_file = artifacthub_matches
                         .get_one::<String>("questions-path")
                         .map(|output| PathBuf::from_str(output).unwrap());
-                    println!(
-                        "{}",
-                        scaffold::artifacthub(metadata_file, version, questions_file)?
-                    );
+                    let content = scaffold::artifacthub(metadata_file, version, questions_file)?;
+                    if let Some(output) = artifacthub_matches.get_one::<String>("output") {
+                        let output_path = PathBuf::from_str(output)?;
+                        fs::write(output_path, content)?;
+                    } else {
+                        println!("{}", content);
+                    }
                 }
             }
             if let Some(matches) = matches.subcommand_matches("scaffold") {


### PR DESCRIPTION
## Description

Adds a new command line argument for the `scaffold artifacthub` subcommand to allow users to define where the artifacthub file content will be written. The new flag is optional. When not defined the content of the file will be written in the stdout.


