### PR TITLE
chore(deps): update mdcat to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.4.0"
 # It's necessary to set the "static" feature in mdcat to avoid the usage of 
 # native-ssl. Using the rustls instead. Otherwise, the build will fail due the 
 # missing OpenSSL lib.
-mdcat = { version = "1.1", default-features = false, features = ["static"] }
+mdcat = { version = "1.1.1", default-features = false, features = ["static"] }
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.9.0" }
 pretty-bytes = "0.2.2"
 prettytable-rs = "^0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -660,14 +660,7 @@ async fn parse_pull_and_run_settings(matches: &ArgMatches) -> Result<run::PullAn
             .map(|destination| PathBuf::from_str(destination).unwrap())
             .ok_or_else(|| anyhow!("Cannot parse 'record-host-capabilities-interactions' file"))?;
 
-        // TODO: replace eprintln with info
-        // once https://github.com/swsnr/mdcat/issues/242 is fixed
-        // info!(session_file = ?destination, "host capabilities proxy enabled with record mode");
-        // print to stderr to not mess with commands that handle the json output
-        // produce by kwctl
-        eprintln!(
-            "host capabilities proxy enabled with record mode. Contents saved to {destination:?}"
-        );
+        info!(session_file = ?destination, "host capabilities proxy enabled with record mode");
         host_capabilities_mode =
             HostCapabilitiesMode::Proxy(callback_handler::ProxyMode::Record { destination });
     }
@@ -677,15 +670,7 @@ async fn parse_pull_and_run_settings(matches: &ArgMatches) -> Result<run::PullAn
             .map(|source| PathBuf::from_str(source).unwrap())
             .ok_or_else(|| anyhow!("Cannot parse 'replay-host-capabilities-interaction' file"))?;
 
-        // TODO: replace eprintln with info
-        // once https://github.com/swsnr/mdcat/issues/242 is fixed
-        // info!(session_file = ?source, "host capabilities proxy enabled with replay mode");
-        // print to stderr to not mess with commands that handle the json output
-        // produce by kwctl
-        eprintln!(
-            "host capabilities proxy enabled with replay mode. Host capabilities interactions taken from {source:?}"
-        );
-
+        info!(session_file = ?source, "host capabilities proxy enabled with replay mode");
         host_capabilities_mode =
             HostCapabilitiesMode::Proxy(callback_handler::ProxyMode::Replay { source });
     }


### PR DESCRIPTION
By updating to latest version, `info` messages are now shown to our users.
Because of that, we can address some `TODO` items we had left.
