### PR TITLE
fix: address small leftover

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use clap::crate_version;
 use itertools::Itertools;
-use policy_evaluator::{burrego, policy_fetcher::store::Store};
+use policy_evaluator::{
+    burrego,
+    policy_fetcher::store::{Store, DEFAULT_ROOT},
+};
 
 pub(crate) fn info() -> Result<()> {
     let builtins: String = burrego::get_builtins()
@@ -18,11 +21,13 @@ pub(crate) fn info() -> Result<()> {
 Open Policy Agent/Gatekeeper implemented builtins:
 {}
 
-Policy store: {}"
+Policy store: {}
+Config directory: {}
     "#,
         crate_version!(),
         builtins,
-        store.root.to_string_lossy()
+        store.root.to_string_lossy(),
+        DEFAULT_ROOT.config_dir().to_string_lossy(),
     );
 
     Ok(())


### PR DESCRIPTION
The `info` command was printing a `"` symbol.

While working on that, I've also made the command print the path of the directory where the default configuration is stored.
