### PR TITLE
fix: hide walrus warning message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,8 @@ async fn main() -> Result<()> {
         .add_directive("cranelift_wasm=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
         .add_directive("hyper=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
         .add_directive("regalloc=off".parse().unwrap()) // this crate generates lots of tracing events we don't care about
-        .add_directive("wasmtime_cache=off".parse().unwrap()); // wasmtime_cache messages are not critical and just confuse users
+        .add_directive("wasmtime_cache=off".parse().unwrap()) // wasmtime_cache messages are not critical and just confuse users
+        .add_directive("walrus=warn".parse().unwrap()); // walrus: ignore warning messages
     tracing_subscriber::registry()
         .with(filter_layer)
         .with(fmt::layer().with_writer(std::io::stderr))


### PR DESCRIPTION
Walrus prints an innocent warning message while annotating a policy.
This can cause users to be confused.

This commit suppresses all the warning messages produced by walrus, but leaves the error ones untouched.

Fixes https://github.com/kubewarden/kwctl/issues/461

