### PR TITLE
chore(deps): remove `pretty-bytes` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,17 +355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,15 +1904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,15 +2056,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -2170,6 +2141,15 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -2628,12 +2608,12 @@ dependencies = [
  "clap_complete",
  "directories",
  "flate2",
+ "humansize",
  "itertools",
  "k8s-openapi",
  "lazy_static",
  "mdcat",
  "policy-evaluator",
- "pretty-bytes",
  "prettytable-rs",
  "pulldown-cmark 0.9.2",
  "regex",
@@ -3685,16 +3665,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "pretty-bytes"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009d6edd2c1dbf2e1c0cd48a2f7766e03498d49ada7109a01c6911815c685316"
-dependencies = [
- "atty",
- "getopts",
-]
 
 [[package]]
 name = "prettytable-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap_complete = "4.1"
 clap = { version = "4.0", features = [ "cargo", "env" ] }
 directories = "5.0.0"
 flate2 = "1.0.25"
+humansize = "2.1"
 itertools = "0.10.5"
 k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_25"] }
 lazy_static = "1.4.0"
@@ -23,7 +24,6 @@ lazy_static = "1.4.0"
 # missing OpenSSL lib.
 mdcat = { version = "1.1.1", default-features = false, features = ["static"] }
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.9.2" }
-pretty-bytes = "0.2.2"
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.9.2", default-features = false }
 regex = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ extern crate anyhow;
 extern crate clap;
 extern crate directories;
 extern crate policy_evaluator;
-extern crate pretty_bytes;
 #[macro_use]
 extern crate prettytable;
 extern crate serde_yaml;

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -3,7 +3,6 @@ use policy_evaluator::{
     policy_fetcher::{policy::Policy, store::Store},
     policy_metadata::Metadata as PolicyMetadata,
 };
-use pretty_bytes::converter::convert;
 use prettytable::{format, Table};
 
 pub(crate) fn list() -> Result<()> {
@@ -51,7 +50,7 @@ pub(crate) fn list() -> Result<()> {
             mutating,
             context_aware,
             sha256sum,
-            convert(policy_filesystem_metadata.len() as f64),
+            humansize::format_size(policy_filesystem_metadata.len(), humansize::DECIMAL),
         ]);
     }
     table.printstd();


### PR DESCRIPTION
Remove the `pretty-bytes` dependency, it's no longer maintained and requires other libraries that are maintained and have security issues.

To be more specific, the `pretty-bytes` crate causes the inclusion of `atty`, which is affected by this issue: https://rustsec.org/advisories/RUSTSEC-2021-0145

This commit replaces `pretty-bytes` with `humansize`, a crate that performs the same task but is more actively maintained.
