### PR TITLE
(feat) added feature to disable colorful output with --no-color flag

### DIFF
--- a/e2e-tests/e2e.bats
+++ b/e2e-tests/e2e.bats
@@ -158,3 +158,20 @@ kwctl() {
     [[ "$privileged_https_sha" = $(sha256sum $XDG_CACHE_HOME/kubewarden/store/https/github.com/kubewarden/pod-privileged-policy/releases/download/v0.1.9/policy.wasm) ]]
     rm policies.tar.gz
  }
+
+ @test "CLI app outputs colored text by default" {
+    kwctl pull registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    kwctl inspect registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    [ "$status" -eq 0 ]
+    [ "${output}" != "" ]
+    [[ "${output}" == *$'\e['* ]]  # Check if output contains ANSI escape sequences
+ }
+
+@test "CLI app honors --no-color flag and disables colored output" {
+    kwctl pull registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    kwctl --no-color inspect registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+    [ "$status" -eq 0 ]
+    [ "${output}" != "" ]
+    [[ "${output}" != *$'\e['* ]]  # Check if output does not contain ANSI escape sequences
+ }
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -616,6 +616,12 @@ pub fn build_cli() -> Command {
                 .num_args(0)
                 .help("Increase verbosity"),
         )
+        .arg(
+            Arg::new("no-color")
+                .long("no-color")
+                .num_args(0)
+                .help("Disable colorful output"),
+        )
         .subcommands(subcommands)
         .long_version(VERSION_AND_BUILTINS.as_str())
         .subcommand_required(true)

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -18,6 +18,7 @@ use pulldown_cmark_mdcat::{
     terminal::{TerminalProgram, TerminalSize},
 };
 use std::convert::TryFrom;
+use std::env;
 use syntect::parsing::SyntaxSet;
 
 pub(crate) async fn inspect(uri: &str, output: OutputType, sources: Option<Sources>) -> Result<()> {
@@ -235,8 +236,16 @@ impl MetadataPrinter {
         let size = TerminalSize::detect().unwrap_or_default();
         let columns = size.columns;
         let terminal = TerminalProgram::detect();
+        let mut capabilities = terminal.capabilities();
+
+        if let Ok(val) = env::var("TERM") {
+            if val == "dumb" {
+                capabilities.style = None;
+            }
+        }
+
         let settings = pulldown_cmark_mdcat::Settings {
-            terminal_capabilities: terminal.capabilities(),
+            terminal_capabilities: capabilities,
             terminal_size: TerminalSize { columns, ..size },
             syntax_set: &SyntaxSet::load_defaults_newlines(),
             theme: pulldown_cmark_mdcat::Theme::default(),

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -13,15 +13,20 @@ use policy_evaluator::{
 };
 use prettytable::{format::FormatBuilder, Table};
 use pulldown_cmark::{Options, Parser};
+use pulldown_cmark_mdcat::TerminalCapabilities;
 use pulldown_cmark_mdcat::{
     resources::NoopResourceHandler,
     terminal::{TerminalProgram, TerminalSize},
 };
 use std::convert::TryFrom;
-use std::env;
 use syntect::parsing::SyntaxSet;
 
-pub(crate) async fn inspect(uri: &str, output: OutputType, sources: Option<Sources>) -> Result<()> {
+pub(crate) async fn inspect(
+    uri: &str,
+    output: OutputType,
+    sources: Option<Sources>,
+    no_color: bool,
+) -> Result<()> {
     let uri = crate::utils::map_path_to_uri(uri)?;
     let wasm_path = crate::utils::wasm_path(uri.as_str())?;
     let metadata_printer = MetadataPrinter::from(&output);
@@ -32,7 +37,7 @@ pub(crate) async fn inspect(uri: &str, output: OutputType, sources: Option<Sourc
     let signatures = fetch_signatures_manifest(uri.as_str(), sources).await;
 
     match metadata {
-        Some(metadata) => metadata_printer.print(&metadata)?,
+        Some(metadata) => metadata_printer.print(&metadata, no_color)?,
         None => return Err(anyhow!(
             "No Kubewarden metadata found inside of '{}'.\nPolicies can be annotated with the `kwctl annotate` command.",
             uri
@@ -98,7 +103,7 @@ impl From<&OutputType> for MetadataPrinter {
 }
 
 impl MetadataPrinter {
-    fn print(&self, metadata: &Metadata) -> Result<()> {
+    fn print(&self, metadata: &Metadata, no_color: bool) -> Result<()> {
         match self {
             MetadataPrinter::Yaml => {
                 let metadata_yaml = serde_yaml::to_string(metadata)?;
@@ -108,13 +113,13 @@ impl MetadataPrinter {
             MetadataPrinter::Pretty => {
                 self.print_metadata_generic_info(metadata)?;
                 println!();
-                self.print_metadata_rules(metadata)?;
+                self.print_metadata_rules(metadata, no_color)?;
                 println!();
                 if !metadata.context_aware_resources.is_empty() {
-                    self.print_metadata_context_aware_resources(metadata)?;
+                    self.print_metadata_context_aware_resources(metadata, no_color)?;
                     println!();
                 }
-                self.print_metadata_usage(metadata)
+                self.print_metadata_usage(metadata, no_color)
             }
         }
     }
@@ -175,7 +180,7 @@ impl MetadataPrinter {
         Ok(())
     }
 
-    fn print_metadata_rules(&self, metadata: &Metadata) -> Result<()> {
+    fn print_metadata_rules(&self, metadata: &Metadata, no_color: bool) -> Result<()> {
         let rules_yaml = serde_yaml::to_string(&metadata.rules)?;
 
         // Quick hack to print a colorized "Rules" section, with the same
@@ -186,10 +191,14 @@ impl MetadataPrinter {
         table.printstd();
 
         let text = format!("```yaml\n{rules_yaml}```");
-        self.render_markdown(&text)
+        self.render_markdown(&text, no_color)
     }
 
-    fn print_metadata_context_aware_resources(&self, metadata: &Metadata) -> Result<()> {
+    fn print_metadata_context_aware_resources(
+        &self,
+        metadata: &Metadata,
+        no_color: bool,
+    ) -> Result<()> {
         let resources_yaml = serde_yaml::to_string(&metadata.context_aware_resources)?;
 
         // Quick hack to print a colorized "Context Aware" section, with the same
@@ -204,13 +213,13 @@ impl MetadataPrinter {
         );
 
         let text = format!("```yaml\n{resources_yaml}```");
-        self.render_markdown(&text)?;
+        self.render_markdown(&text, no_color)?;
         println!("To avoid abuses, review carefully what the policy requires access to.");
 
         Ok(())
     }
 
-    fn print_metadata_usage(&self, metadata: &Metadata) -> Result<()> {
+    fn print_metadata_usage(&self, metadata: &Metadata, no_color: bool) -> Result<()> {
         let usage = match metadata.annotations.clone() {
             None => None,
             Some(annotations) => annotations
@@ -229,20 +238,22 @@ impl MetadataPrinter {
         table.add_row(row![Fmbl -> "Usage"]);
         table.printstd();
 
-        self.render_markdown(&usage.unwrap())
+        self.render_markdown(&usage.unwrap(), no_color)
     }
 
-    fn render_markdown(&self, text: &str) -> Result<()> {
+    fn render_markdown(&self, text: &str, no_color: bool) -> Result<()> {
         let size = TerminalSize::detect().unwrap_or_default();
         let columns = size.columns;
         let terminal = TerminalProgram::detect();
-        let mut capabilities = terminal.capabilities();
 
-        if let Ok(val) = env::var("TERM") {
-            if val == "dumb" {
-                capabilities.style = None;
+        let capabilities = if no_color {
+            TerminalCapabilities {
+                style: None,
+                ..terminal.capabilities()
             }
-        }
+        } else {
+            terminal.capabilities()
+        };
 
         let settings = pulldown_cmark_mdcat::Settings {
             terminal_capabilities: capabilities,

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,6 @@ lazy_static! {
 #[tokio::main]
 async fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();
-
-    // setup color
     let mut term_color_support = "dumb".to_string();
 
     if let Ok(val) = env::var("TERM") {
@@ -319,7 +317,7 @@ async fn main() -> Result<()> {
                 )?;
                 let sources = remote_server_options(matches)?;
 
-                inspect::inspect(uri, output, sources).await?;
+                inspect::inspect(uri, output, sources, no_color).await?;
             };
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,9 @@ async fn main() -> Result<()> {
         .unwrap_or(&false)
         .to_owned();
 
+    // Need to set this env variable to have prettytable
+    // adapt the output. This can later be removed if
+    // prettytable provides methods to disable color globally
     if no_color {
         env::set_var("TERM", "dumb");
     } else {


### PR DESCRIPTION
## Description
The `--no-color` flag removes color from the output. It also disables color from the logs genearted by `tracing` crate.

Fixes #195 

## Additional Information
I am modifying the `TERM` env variable to disable color. This is referenced from [here](https://docs.rs/termcolor/1.2.0/src/termcolor/lib.rs.html#255). The changes made to the TERM variable using `env::set_var("TERM", ...)` are specific to the current process and its child processes. Once the process terminates, the environment variable will revert to its previous value.

<!--

### Tradeoff
Please describe, if any, the tradeoffs that you found acceptable in this pull request 

### Potential improvement
Please describe, if any, potential improvement that you are envisioning 
-->
