### PR TITLE
Bump v1.7.0-rc1 version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.6.0"
+version = "1.7.0-rc1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.6.0"
+version = "1.7.0-rc1"
 authors = [
         "Kubewarden Developers <kubewarden@suse.de>"
 ]


### PR DESCRIPTION
## Description

Updates the Cargo.toml and Cargo.lock file bumping the version to v1.7.0-rc1.

Related to https://github.com/kubewarden/kubewarden-controller/issues/473

