### PR TITLE
fix: publish release drafter draft release.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,6 +6,7 @@ categories:
   - title: '🚀 Features'
     labels:
       - 'kind/enhancement'
+      - 'kind/feature'
   - title: '🐛 Bug Fixes'
     labels:
       - 'kind/bug'
@@ -34,14 +35,16 @@ autolabeler:
     title: '/.*!:.*/'
   - label: 'area/dependencies'
     title: 'chore(deps)'
-  - label: 'kind/enhancement'
+  - label: 'area/dependencies'
+    title: 'fix(deps)'
+  - label: 'area/dependencies'
+    title: 'build(deps)'
+  - label: 'kind/feature'
     title: 'feat'
   - label: 'kind/bug'
     title: 'fix'
   - label: 'kind/chore'
     title: 'chore'
-  - label: 'area/dependencies'
-    title: 'build(deps)'
 
 version-resolver:
   major:
@@ -53,11 +56,11 @@ version-resolver:
       - 'kind/minor'
       - 'kind/feature'
       - 'kind/enhancement'
-      - 'area/dependencies'
   patch:
     labels:
       - 'kind/patch'
       - 'kind/fix'
       - 'kind/bug'
       - 'kind/chore'
+      - 'area/dependencies'
   default: patch


### PR DESCRIPTION
## Description

Updates the release CI to publish the draft release created by release drafter instead of creating a new release. Therefore, we will use the nice changelog.

