### PR TITLE
Updates cosign and sbom-generator-installer to v2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           # update the spec file to ensure that.
           sudo sed -i "s/-dynamic-linker.*/-no-dynamic-linker  -nostdlib %{shared:-shared} %{static:-static} %{rdynamic:-no-export-dynamic}/g" /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
 
-      - uses: sigstore/cosign-installer@v2.8.1
+      - uses: sigstore/cosign-installer@v3
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -83,17 +83,19 @@ jobs:
           mv target/${{ matrix.targetarch }}-unknown-linux-musl/release/kwctl kwctl-linux-${{ matrix.targetarch }}
 
       - name: Sign kwctl
-        run: cosign sign-blob kwctl-linux-${{ matrix.targetarch }} --output-certificate kwctl-linux-${{ matrix.targetarch}}.pem --output-signature kwctl-linux-${{ matrix.targetarch }}.sig
-        env:
-          COSIGN_EXPERIMENTAL: 1
+        run: cosign sign-blob --yes kwctl-linux-${{ matrix.targetarch }} --output-certificate kwctl-linux-${{ matrix.targetarch}}.pem --output-signature kwctl-linux-${{ matrix.targetarch }}.sig
+
       - run: zip -j9 kwctl-linux-${{ matrix.targetarch }}.zip kwctl-linux-${{ matrix.targetarch }} kwctl-linux-${{ matrix.targetarch }}.sig kwctl-linux-${{ matrix.targetarch }}.pem
+
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:
           name: kwctl-linux-${{ matrix.targetarch }}
           path: kwctl-linux-${{ matrix.targetarch }}.zip
+
       - name: Install SBOM generator tool
-        uses: kubewarden/github-actions/sbom-generator-installer@v1
+        uses: kubewarden/github-actions/sbom-generator-installer@v2
+
       - name: Generate SBOM
         run: |
           spdx-sbom-generator -f json
@@ -103,11 +105,9 @@ jobs:
 
       - name: Sign BOM file
         run: |
-          cosign sign-blob --output-certificate kwctl-linux-${{ matrix.targetarch }}-sbom.spdx.cert \
+          cosign sign-blob --yes --output-certificate kwctl-linux-${{ matrix.targetarch }}-sbom.spdx.cert \
             --output-signature kwctl-linux-${{ matrix.targetarch }}-sbom.spdx.sig \
             kwctl-linux-${{ matrix.targetarch }}-sbom.spdx.json
-        env:
-          COSIGN_EXPERIMENTAL: 1
 
       - name: Upload kwctl SBOM files
         uses: actions/upload-artifact@v2
@@ -136,7 +136,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@v2.8.1
+
+      - uses: sigstore/cosign-installer@v3
+
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -145,23 +147,28 @@ jobs:
           override: true
 
       - run: rustup target add ${{ matrix.targetarch }}-apple-darwin
+
       - name: Build kwctl
         run: cargo build --target=${{ matrix.targetarch }}-apple-darwin --release
+
       - run: mv target/${{ matrix.targetarch }}-apple-darwin/release/kwctl kwctl-darwin-${{ matrix.targetarch }}
+
       - name: Sign kwctl
-        run: cosign sign-blob kwctl-darwin-${{ matrix.targetarch }} --output-certificate kwctl-darwin-${{ matrix.targetarch }}.pem --output-signature kwctl-darwin-${{ matrix.targetarch }}.sig
-        env:
-          COSIGN_EXPERIMENTAL: 1
+        run: cosign sign-blob --yes kwctl-darwin-${{ matrix.targetarch }} --output-certificate kwctl-darwin-${{ matrix.targetarch }}.pem --output-signature kwctl-darwin-${{ matrix.targetarch }}.sig
+
       - run: zip -j9 kwctl-darwin-${{ matrix.targetarch }}.zip kwctl-darwin-${{ matrix.targetarch }} kwctl-darwin-${{ matrix.targetarch }}.sig kwctl-darwin-${{ matrix.targetarch }}.pem
+
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:
           name: kwctl-darwin-${{ matrix.targetarch }}
           path: kwctl-darwin-${{ matrix.targetarch }}.zip
+
       - name: Install SBOM generator tool
-        uses: kubewarden/github-actions/sbom-generator-installer@v1
+        uses: kubewarden/github-actions/sbom-generator-installer@v2
         with:
           sbom-generator-arch: darwin-amd64
+
       - name: Generate SBOM
         run: |
           spdx-sbom-generator -f json
@@ -171,11 +178,9 @@ jobs:
 
       - name: Sign BOM file
         run: |
-          cosign sign-blob --output-certificate kwctl-darwin-${{ matrix.targetarch }}-sbom.spdx.cert \
+          cosign sign-blob --yes --output-certificate kwctl-darwin-${{ matrix.targetarch }}-sbom.spdx.cert \
             --output-signature kwctl-darwin-${{ matrix.targetarch }}-sbom.spdx.sig \
             kwctl-darwin-${{ matrix.targetarch }}-sbom.spdx.json
-        env:
-          COSIGN_EXPERIMENTAL: 1
 
       - name: Upload kwctl SBOM files
         uses: actions/upload-artifact@v2
@@ -193,27 +198,33 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@v2.8.1
+
+      - uses: sigstore/cosign-installer@v3
+
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - run: rustup target add x86_64-pc-windows-msvc
+
       - name: Build kwctl
+
         run: cargo build --target=x86_64-pc-windows-msvc --release
       - run: mv target/x86_64-pc-windows-msvc/release/kwctl.exe kwctl-windows-x86_64.exe
+
       - name: Sign kwctl
-        run: cosign sign-blob kwctl-windows-x86_64.exe --output-certificate kwctl-windows-x86_64.pem --output-signature kwctl-windows-x86_64.sig
-        env:
-          COSIGN_EXPERIMENTAL: 1
+        run: cosign sign-blob --yes kwctl-windows-x86_64.exe --output-certificate kwctl-windows-x86_64.pem --output-signature kwctl-windows-x86_64.sig
+
       - run: |
           "/c/Program Files/7-Zip/7z.exe" a kwctl-windows-x86_64.exe.zip kwctl-windows-x86_64.exe kwctl-windows-x86_64.sig kwctl-windows-x86_64.pem
         shell: bash
+
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:
           name: kwctl-windows-x86_64
           path: kwctl-windows-x86_64.exe.zip
+
       - name: Generate SBOM
         run: |
           # if change the version used, remember to update the default version used for
@@ -228,9 +239,7 @@ jobs:
 
       - name: Sign BOM file
         run: |
-          cosign sign-blob --output-certificate kwctl-windows-x86_64-sbom.spdx.cert --output-signature kwctl-windows-x86_64-sbom.spdx.sig kwctl-windows-x86_64-sbom.spdx.json
-        env:
-          COSIGN_EXPERIMENTAL: 1
+          cosign sign-blob --yes --output-certificate kwctl-windows-x86_64-sbom.spdx.cert --output-signature kwctl-windows-x86_64-sbom.spdx.sig kwctl-windows-x86_64-sbom.spdx.json
 
       - name: Upload kwctl SBOM files
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,15 @@ jobs:
   code-checks:
     name: Basic source code checks
     uses: ./.github/workflows/source-code-checks.yml
+
   cargo-checks:
     name: Cargo file checks
     uses: ./.github/workflows/cargo-file-checks.yml
+
   tests:
     name: Running tests
     uses: ./.github/workflows/tests.yml
+
   build:
     name: Build kwctl
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.5.0
-      - uses: sigstore/cosign-installer@v2.8.1
-        with:
-          cosign-release: v1.13.1
+
+      - uses: sigstore/cosign-installer@v3
+
       - name: run e2e tests
         run: make e2e-test


### PR DESCRIPTION
## Description

Updates the CI scripts updating the cosign-installer to v3. Thus, the cosign version now is v2. Which has breaking changes requiring some changes on how the command is called and removing the need of using environment variable to enable keyless signature.

Also updates the sbom-generator-installer action to version v2.

Related to https://github.com/kubewarden/kubewarden-controller/issues/411