### PR TITLE
fix: Ensure release assets have proper name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,19 +19,19 @@ jobs:
       id-token: write
 
     steps:
-      - uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3
+      - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
       - name: setup rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable
           target: ${{matrix.targetarch}}-unknown-linux-musl
           override: true
 
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
+      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
         with:
           use-cross: true
           command: build
@@ -45,7 +45,7 @@ jobs:
       - run: zip -j9 kwctl-linux-${{ matrix.targetarch }}.zip kwctl-linux-${{ matrix.targetarch }} kwctl-linux-${{ matrix.targetarch }}.sig kwctl-linux-${{ matrix.targetarch }}.pem
 
       - name: Upload binary
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: kwctl-linux-${{ matrix.targetarch }}
           path: kwctl-linux-${{ matrix.targetarch }}.zip
@@ -72,7 +72,7 @@ jobs:
             kwctl-linux-${{ matrix.targetarch }}-sbom.spdx
 
       - name: Upload kwctl SBOM files
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: kwctl-linux-${{ matrix.targetarch }}-sbom
           path: |
@@ -81,7 +81,7 @@ jobs:
             kwctl-linux-${{ matrix.targetarch }}-sbom.spdx.sig
 
       - name: Upload kwctl air gap scripts
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: kwctl-airgap-scripts
           path: |
@@ -97,12 +97,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
-      - uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3
+      - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Setup rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable
           target: ${{ matrix.targetarch }}-apple-darwin
@@ -111,7 +111,10 @@ jobs:
       - run: rustup target add ${{ matrix.targetarch }}-apple-darwin
 
       - name: Build kwctl
-        run: cargo build --target=${{ matrix.targetarch }}-apple-darwin --release
+        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
+        with:
+          command: build
+          args: --target=${{ matrix.targetarch }}-apple-darwin --release
 
       - run: mv target/${{ matrix.targetarch }}-apple-darwin/release/kwctl kwctl-darwin-${{ matrix.targetarch }}
 
@@ -125,13 +128,13 @@ jobs:
       - run: zip -j9 kwctl-darwin-${{ matrix.targetarch }}.zip kwctl-darwin-${{ matrix.targetarch }} kwctl-darwin-${{ matrix.targetarch }}.sig kwctl-darwin-${{ matrix.targetarch }}.pem
 
       - name: Upload binary
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: kwctl-darwin-${{ matrix.targetarch }}
           path: kwctl-darwin-${{ matrix.targetarch }}.zip
 
       - name: Install the syft command
-        uses: kubewarden/github-actions/syft-installer@0b73198f5d655ef4ad84e423f8047044ed73fd4b
+        uses: kubewarden/github-actions/syft-installer@0b73198f5d655ef4ad84e423f8047044ed73fd4b # v3.1.9
         with:
           arch: darwin_amd64
 
@@ -154,7 +157,7 @@ jobs:
             kwctl-darwin-${{ matrix.targetarch }}-sbom.spdx
 
       - name: Upload kwctl SBOM files
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: kwctl-darwin-${{ matrix.targetarch }}-sbom
           path: |
@@ -173,19 +176,22 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
-      - uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3
+      - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Setup rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable
       - run: rustup target add x86_64-pc-windows-msvc
 
       - name: Build kwctl
+        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
+        with:
+          command: build
+          args: --target=x86_64-pc-windows-msvc --release
 
-        run: cargo build --target=x86_64-pc-windows-msvc --release
       - run: mv target/x86_64-pc-windows-msvc/release/kwctl.exe kwctl-windows-x86_64.exe
 
       - name: Smoke test build
@@ -199,7 +205,7 @@ jobs:
         shell: bash
 
       - name: Upload binary
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: kwctl-windows-x86_64
           path: kwctl-windows-x86_64.exe.zip
@@ -229,7 +235,7 @@ jobs:
           kwctl-windows-x86_64-sbom.spdx
 
       - name: Upload kwctl SBOM files
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: kwctl-windows-x86_64-sbom
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,85 +6,41 @@ env:
 
 jobs:
   build-linux-binaries:
-    name: Build linux binary
-    runs-on: ubuntu-22.04
+    name: Build linux binaries
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        targetarch: [ "aarch64", "x86_64" ]
-        include:
-          - targetarch: aarch64
-            arch: arm64
-            rustflags: ""
-          - targetarch: x86_64
-            arch: amd64
-            rustflags: "-C target-feature=+crt-static"
+        targetarch:
+          - aarch64
+          - x86_64
+
     permissions:
       packages: write
       id-token: write
 
     steps:
-      - name: Configure Ubuntu repositories
-        run: |
-          sudo dpkg --add-architecture arm64
+      - uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3
 
-          sudo sed -i "s/deb h/deb [arch=amd64] h/g" /etc/apt/sources.list
+      - name: checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy universe" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates universe" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy multiverse" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates multiverse" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security universe" /etc/apt/sources.list
-          sudo sed -i "$ a deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security multiverse" /etc/apt/sources.list
-
-          sudo apt update -y
-      - name: Install dependencies
-        run: |
-          sudo apt install -y libssl-dev:${{ matrix.arch }}
-
-      - name: Install Musl and configure gcc spec
-        run: |
-          sudo apt install -y musl-dev:${{ matrix.arch }}
-          # patching the .spec file, as by default it has a bug where it tries to
-          # set old_cpp_options but it already exists. using *+cpp_options achieves
-          # the same desired functionality of appending preexisting options
-          sudo sed -i 1d /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
-          sudo sed -i "s/*cpp_options/+cpp_options/g" /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
-          sudo sed -i "s/ %(old_cpp_options)//g" /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
-
-      - name: Configure gcc spec for x86_64
-        if: ${{ matrix.targetarch == 'x86_64' }}
-        run: |
-          # The cargo configuration to build static binaries is not working. Thus,
-          # update the spec file to ensure that.
-          sudo sed -i "s/-dynamic-linker.*/-no-dynamic-linker  -nostdlib %{shared:-shared} %{static:-static} %{rdynamic:-no-export-dynamic}/g" /usr/lib/${{ matrix.targetarch }}-linux-musl/musl-gcc.specs
-
-      - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3
-
-      - name: Checkout code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v2
-
-      - name: Setup rust toolchain
+      - name: setup rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
+          target: ${{matrix.targetarch}}-unknown-linux-musl
+          override: true
 
-      - name: Install rust target
-        run: rustup target add ${{ matrix.targetarch }}-unknown-linux-musl
-
-      - name: Build kwctl
-        env:
-          CC: ${{ matrix.targetarch }}-linux-musl-gcc
-          RUSTFLAGS: "-C link_arg=-lgcc -C link_arg=-specs -C link_arg=/usr/lib/${{ matrix.targetarch}}-linux-musl/musl-gcc.specs ${{ matrix.rustflags }}"
-        run: |
-          cargo build --release --target ${{ matrix.targetarch }}-unknown-linux-musl
-          mv target/${{ matrix.targetarch }}-unknown-linux-musl/release/kwctl kwctl-linux-${{ matrix.targetarch }}
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target ${{matrix.targetarch}}-unknown-linux-musl
 
       - name: Sign kwctl
-        run: cosign sign-blob --yes kwctl-linux-${{ matrix.targetarch }} --output-certificate kwctl-linux-${{ matrix.targetarch}}.pem --output-signature kwctl-linux-${{ matrix.targetarch }}.sig
+        run: |
+          mv target/${{ matrix.targetarch }}-unknown-linux-musl/release/kwctl kwctl-linux-${{ matrix.targetarch }}
+          cosign sign-blob --yes kwctl-linux-${{ matrix.targetarch }} --output-certificate kwctl-linux-${{ matrix.targetarch}}.pem --output-signature kwctl-linux-${{ matrix.targetarch }}.sig
 
       - run: zip -j9 kwctl-linux-${{ matrix.targetarch }}.zip kwctl-linux-${{ matrix.targetarch }} kwctl-linux-${{ matrix.targetarch }}.sig kwctl-linux-${{ matrix.targetarch }}.pem
 
@@ -136,14 +92,14 @@ jobs:
     name: Build darwin binary
     strategy:
       matrix:
-        targetarch: [ "aarch64", "x86_64" ]
+        targetarch: ["aarch64", "x86_64"]
     runs-on: macos-latest
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-      - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3
+      - uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
@@ -211,15 +167,15 @@ jobs:
     strategy:
       matrix:
         # workaround to have the same GH UI for all jobs
-        targetarch: [ "x86_64" ]
-        os: [ "windows-latest" ]
+        targetarch: ["x86_64"]
+        os: ["windows-latest"]
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-      - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3
+      - uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     name: Cargo check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
+      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
         with:
           command: check
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download source code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v2
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Check cargo file version
         run: |
           CARGO_VERSION=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)
@@ -47,13 +47,13 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
+      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
         with:
           command: test
           args: --workspace
@@ -62,9 +62,9 @@ jobs:
     name: E2E tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v2
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Setup BATS
-        uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1
+        uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1.2.0
         with:
           bats-version: 1.5.0
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3
@@ -75,14 +75,14 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
+      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
         with:
           command: fmt
           args: --all -- --check
@@ -91,14 +91,14 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
+      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
         with:
           command: clippy
           args: -- -D warnings
@@ -108,14 +108,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+
       - run: shellcheck $(find scripts/ -name '*.sh')
 
   airgap-e2e-test:
     name: Airgap E2E test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3.5.3
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Run registry
         run: |
           export CONTAINER_ID=$(docker run -d -p 5000:5000 --name registry registry:2)

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -2,9 +2,9 @@ name: fossa scanning
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
     branches:
-      - 'main'
+      - "main"
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -13,7 +13,7 @@ jobs:
   fossa-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f # v1.3.1
         with:
           api-key: ${{secrets.FOSSA_API_TOKEN}}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 # v5
+      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 # v5.24.0
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get latest release tag
         id: get_last_release_tag
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let release = await github.rest.repos.getLatestRelease({
@@ -57,7 +57,7 @@ jobs:
             core.setFailed("Cannot find latest release")
 
       - name: Get release ID from the release created by release drafter
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let releases = await github.rest.repos.listReleases({
@@ -74,7 +74,7 @@ jobs:
             core.setFailed(`Draft release not found`)
 
       - name: Download all artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         # no name provided, download all artifacts. Puts them in folders.
 
       - name: Display structure of downloaded files
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload release assets
         id: upload_release_assets
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let fs = require('fs');
@@ -127,7 +127,7 @@ jobs:
             }
 
       - name: Publish release
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const {RELEASE_ID} = process.env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
         with:
           script: |
             let fs = require('fs');
+            let path = require('path');
+
             let files = [
               './kwctl-airgap-scripts/kubewarden-load-policies.sh',
               './kwctl-airgap-scripts/kubewarden-save-policies.sh',
@@ -119,7 +121,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 release_id: `${RELEASE_ID}`,
-                name: file,
+                name: path.basename(file),
                 data: file_data,
               });
             }

--- a/.github/workflows/security-audit-cron.yml
+++ b/.github/workflows/security-audit-cron.yml
@@ -1,7 +1,7 @@
 name: Security audit cron job
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -10,7 +10,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3
-      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-audit-reactive.yml
+++ b/.github/workflows/security-audit-reactive.yml
@@ -1,9 +1,9 @@
 name: Security audit
 on:
   push:
-    paths: 
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -12,7 +12,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3
-      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_execution_mode_cannot_be_opa_or_gatekeeper_for_a_kubewarden_policy() {
-        for execution_mode in vec![PolicyExecutionMode::Opa, PolicyExecutionMode::OpaGatekeeper] {
+        for execution_mode in [PolicyExecutionMode::Opa, PolicyExecutionMode::OpaGatekeeper] {
             let metadata = Metadata {
                 execution_mode,
                 ..Default::default()

--- a/src/run.rs
+++ b/src/run.rs
@@ -424,12 +424,12 @@ mod tests {
     #[test]
     fn test_determine_execution_mode_metadata_is_not_set_and_user_mode_is_set_but_the_user_value_is_wrong(
     ) {
-        for mode in vec![
+        for mode in [
             PolicyExecutionMode::Opa,
             PolicyExecutionMode::OpaGatekeeper,
             PolicyExecutionMode::KubewardenWapc,
         ] {
-            let user_execution_mode = Some(mode.clone());
+            let user_execution_mode = Some(mode);
             let metadata = None;
 
             let backend_detector = match mode {
@@ -468,12 +468,12 @@ mod tests {
     #[test]
     fn test_determine_execution_mode_metadata_is_not_set_and_user_mode_is_set_and_the_user_value_is_right(
     ) {
-        for mode in vec![
+        for mode in [
             PolicyExecutionMode::Opa,
             PolicyExecutionMode::OpaGatekeeper,
             PolicyExecutionMode::KubewardenWapc,
         ] {
-            let user_execution_mode = Some(mode.clone());
+            let user_execution_mode = Some(mode);
             let metadata = None;
 
             let backend_detector = match mode {


### PR DESCRIPTION
The GH action uploading the release assets must provide the base name of the file, not its full path.

With kubewarden 1.7.0-rc2 we accidentally got all the release assets to contain the entire path to the file. For example, we had `default.kwctl-airgap-scripts.kubewarden-load-policies.sh` instead of
`kubewarden-load-policies.sh`.
