### PR TITLE
test(poc): use rust to test the cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
 dependencies = [
  "memchr",
+ "regex-automata 0.3.8",
  "serde",
 ]
 
@@ -1110,6 +1126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1479,15 @@ checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2333,6 +2364,7 @@ name = "kwctl"
 version = "1.7.0-rc2"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "clap_complete",
  "directories",
@@ -2342,6 +2374,7 @@ dependencies = [
  "k8s-openapi",
  "lazy_static",
  "policy-evaluator",
+ "predicates",
  "prettytable-rs",
  "pulldown-cmark",
  "pulldown-cmark-mdcat",
@@ -2550,6 +2583,12 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3296,6 +3335,37 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "itertools 0.10.5",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettytable-rs"
@@ -4380,6 +4450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4883,6 +4959,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ flate2 = "1.0.27"
 humansize = "2.1"
 itertools = "0.11.0"
 k8s-openapi = { version = "0.19.0", default-features = false, features = [
-        "v1_27",
+  "v1_27",
 ] }
 lazy_static = "1.4.0"
 pulldown-cmark-mdcat = { version = "2.0.3", default-features = false, features = [
-        "regex-fancy",
+  "regex-fancy",
 ] }
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.11.4" }
 prettytable-rs = "^0.10"
@@ -30,8 +30,8 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.25"
 syntect = { version = "5.0", default-features = false, features = [
-        "default-syntaxes",
-        "parsing",
+  "default-syntaxes",
+  "parsing",
 ] }
 tar = "0.4.40"
 tiny-bench = "0.3"
@@ -50,9 +50,11 @@ semver = { version = "1.0.18", features = ["serde"] }
 # This is required to have kwctl use the system certificates instead of the
 # ones bundled inside of rustls
 reqwest = { version = "0", default-features = false, features = [
-        "rustls-tls-native-roots",
+  "rustls-tls-native-roots",
 ] }
 
 [dev-dependencies]
 rstest = "0.18.2"
 tempfile = "3.8.0"
+assert_cmd = "2.0.12"
+predicates = "3.0.3"

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ lint:
 
 .PHONY: test
 test: fmt lint
-	cargo test --workspace
+	cargo test --workspace --bins
 
 .PHONY: e2e-test
 e2e-test:
-	sh -c 'cd e2e-tests; bats --print-output-on-failure .'
+	cargo test --test '*'
 
 .PHONY: clean
 clean:

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,68 @@
+use common::{load_fixtures, setup_command};
+use predicates::{prelude::*, str::contains};
+use tempfile::tempdir;
+
+mod common;
+
+const POLICIES: &[&str] = &[
+    // SHA: 59e34f482b40
+    "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9",
+    // SHA: 828617a7cf3e
+    "registry://ghcr.io/kubewarden/tests/safe-labels:v0.1.13",
+];
+
+#[test]
+fn test_policies_empty() {
+    let tempdir = tempdir().unwrap();
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("policies");
+    cmd.assert().success();
+    cmd.assert().stdout("");
+}
+
+#[test]
+fn test_policies() {
+    let tempdir = tempdir().unwrap();
+    load_fixtures(tempdir.path(), POLICIES);
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("policies");
+    cmd.assert().success();
+    cmd.assert()
+        .stdout(contains("pod-privileged"))
+        .stdout(contains("v0.1.9"))
+        .stdout(contains("safe-labels"))
+        .stdout(contains("v0.1.13"));
+}
+
+#[test]
+fn test_rm() {
+    let tempdir = tempdir().unwrap();
+    load_fixtures(tempdir.path(), POLICIES);
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("rm")
+        .arg("registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9");
+    cmd.assert().success();
+    cmd.assert().stdout("");
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("policies").assert().success();
+    cmd.assert().stdout(contains("pod-privileged").not());
+}
+
+#[test]
+fn test_rm_with_sha() {
+    let tempdir = tempdir().unwrap();
+    load_fixtures(tempdir.path(), POLICIES);
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("rm").arg("59e3");
+    cmd.assert().success();
+    cmd.assert().stdout("");
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("policies").assert().success();
+    cmd.assert().stdout(contains("59e3").not());
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+use assert_cmd::Command;
+
+pub fn setup_command(path: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("kwctl").unwrap();
+
+    cmd.current_dir(path)
+        .env("XDG_CONFIG_HOME", path.join(".config"))
+        .env("XDG_CACHE_HOME", path.join(".cache"))
+        .env("XDG_DATA_HOME", path.join(".local/share"));
+
+    cmd
+}
+
+pub fn load_fixtures(path: &Path, policies: &[&str]) {
+    for policy in policies {
+        let mut cmd = setup_command(path);
+        cmd.arg("pull").arg(policy);
+
+        cmd.assert().success();
+    }
+}


### PR DESCRIPTION
## Description

This is a POC on how e2e tests could be rewritten in rust, superseeding bats.

The idea is taken from this  book:
https://rust-cli.github.io/book/tutorial/testing.html

Also, some reference in the `ripgrep` project (which uses the same pattern but has a custom macro):
https://github.com/BurntSushi/ripgrep/tree/d2a409f89f1eb8e3ad3990aeb1fff944289534f2/tests

Two dev dependencies were added, `assert_cmd` as a helper to run asserts against the output of the `kwctl` cli programmatically, and `predicates` which helps build composable predicates for the asserts.

Note:
I've modified the Makefile so that `--bins` test is passed to the unit test target. and `--test '*'` is passed to the e2e test target. This way it's possible to separate unit and e2e tests.

## Additional Information
The code could be dried up in several ways, including the usage of `rstest` and macros in general, in particular for the setup functions.