### PR TITLE
Bump v1.7.0-rc3 version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.7.0-rc2"
+version = "1.7.0-rc3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.7.0-rc2"
+version = "1.7.0-rc3"
 authors = ["Kubewarden Developers <kubewarden@suse.de>"]
 edition = "2021"
 


### PR DESCRIPTION
## Description

Updates the Cargo.toml file bumping the version to v1.7.0-rc3.

Related to https://github.com/kubewarden/kubewarden-controller/issues/519
