### PR TITLE
fix: missing step to trigger helm chart update.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,3 +141,11 @@ jobs:
               name: `${TAG_NAME}`,
               prerelease: `${{ contains(github.event.workflow_run.head_branch, '-alpha') || contains(github.event.workflow_run.head_branch, '-beta') || contains(github.event.workflow_run.head_branch, '-rc') }}`
             });
+
+      - name: Trigger chart update
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2.1.2
+        with:
+          token: ${{ secrets.WORKFLOW_PAT }}
+          repository: "${{github.repository_owner}}/helm-charts"
+          event-type: update-chart
+          client-payload: '{"version": "${{ github.ref_name }}", "oldVersion": "${{ steps.get_last_release_tag.outputs.old_release_tag }}", "repository": "${{ github.repository }}"}'


### PR DESCRIPTION
## Description

The release CI script is missing a step to trigger the helm update. This is necessary to sync the release among all the major Kubewarden components.


Related to https://github.com/kubewarden/kubewarden-controller/issues/519
