### PR TITLE
feat: use policyType metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.8.0"
+version = "1.9.0-rc1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.12.0#3f8ffc45f370c7c45a61510554cadd52c88e486a"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.12.1#12f678594e30fc8f69747f272dd9130f9bfe127a"
 dependencies = [
  "base64 0.21.4",
  "chrono",
@@ -3287,8 +3287,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.12.0"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.12.0#3f8ffc45f370c7c45a61510554cadd52c88e486a"
+version = "0.12.1"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.12.1#12f678594e30fc8f69747f272dd9130f9bfe127a"
 dependencies = [
  "anyhow",
  "base64 0.21.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 pulldown-cmark-mdcat = { version = "2.1.0", default-features = false, features = [
   "regex-fancy",
 ] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.12.0" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.12.1" }
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.9.3", default-features = false }
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.8.0"
+version = "1.9.0-rc1"
 authors = ["Kubewarden Developers <kubewarden@suse.de>"]
 edition = "2021"
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -160,6 +160,7 @@ impl MetadataPrinter {
         table.add_row(row![Fgbl -> "mutating:", metadata.mutating]);
         table.add_row(row![Fgbl -> "background audit support:", metadata.background_audit]);
         table.add_row(row![Fgbl -> "context aware:", !metadata.context_aware_resources.is_empty()]);
+        table.add_row(row![Fgbl -> "policy type:", metadata.policy_type]);
         table.add_row(row![Fgbl -> "execution mode:", metadata.execution_mode]);
         if metadata.execution_mode == PolicyExecutionMode::KubewardenWapc {
             table.add_row(row![Fgbl -> "protocol version:", protocol_version]);

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use policy_evaluator::admission_request::AdmissionRequest;
 use policy_evaluator::kube;
+use policy_evaluator::policy_metadata::PolicyType;
 use policy_evaluator::{
     constants::*,
     policy_evaluator::{Evaluator, PolicyEvaluator},
@@ -120,7 +121,7 @@ pub(crate) async fn prepare_run_env(cfg: &PullAndRunSettings) -> Result<RunEnv> 
     }
     let policy_evaluator = policy_evaluator_builder.build()?;
 
-    let request = if cfg.raw {
+    let request = if cfg.raw || has_raw_policy_type(metadata.as_ref()) {
         ValidateRequest::Raw(req_obj)
     } else {
         let req_obj = match req_obj.clone() {
@@ -284,6 +285,14 @@ fn determine_execution_mode(
                 }
             }
         }
+    }
+}
+
+fn has_raw_policy_type(metadata: Option<&Metadata>) -> bool {
+    if let Some(metadata) = metadata {
+        metadata.policy_type == PolicyType::Raw
+    } else {
+        false
     }
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,14 +1,13 @@
 use anyhow::{anyhow, Result};
 use policy_evaluator::admission_request::AdmissionRequest;
 use policy_evaluator::kube;
-use policy_evaluator::policy_metadata::PolicyType;
 use policy_evaluator::{
     constants::*,
     policy_evaluator::{Evaluator, PolicyEvaluator},
     policy_evaluator::{PolicyExecutionMode, ValidateRequest},
     policy_evaluator_builder::PolicyEvaluatorBuilder,
     policy_fetcher::{sources::Sources, verify::FulcioAndRekorData, PullDestination},
-    policy_metadata::{ContextAwareResource, Metadata},
+    policy_metadata::{ContextAwareResource, Metadata, PolicyType},
 };
 use std::{
     collections::HashSet,

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -170,10 +170,25 @@ fn test_run_raw() {
 
     let mut cmd = setup_command(tempdir.path());
     cmd.arg("run")
-        .arg("--raw")
         .arg("--request-path")
         .arg(test_data("raw.json"))
         .arg("registry://ghcr.io/kubewarden/tests/raw-mutation-policy:v0.1.0");
+
+    cmd.assert().success();
+    cmd.assert().stdout(contains("\"allowed\":true"));
+    cmd.assert().stdout(contains("\"patchType\":\"JSONPatch\""));
+}
+
+#[test]
+fn test_run_raw_non_annotated() {
+    let tempdir = tempdir().unwrap();
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("run")
+        .arg("--raw")
+        .arg("--request-path")
+        .arg(test_data("raw.json"))
+        .arg("registry://ghcr.io/kubewarden/tests/raw-mutation-non-annotated-policy:v0.1.0");
 
     cmd.assert().success();
     cmd.assert().stdout(contains("\"allowed\":true"));


### PR DESCRIPTION
## Description

- show policyType when inspecting a policy
- run a policy in raw "mode" if the policyType metadata is set to raw, otherwise the user needs to pass a `--raw` flag (which takes precedence over the metadata, in case the policy is not annotated)
## Test
Adds e2e tests
## Additional Information
Bumps Cargo toml to `v1.9.0-rc1`