### PR TITLE
fix: improve error message when AdmissionRequest is not valid

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -137,7 +137,8 @@ pub(crate) async fn prepare_run_env(cfg: &PullAndRunSettings) -> Result<RunEnv> 
             }
             _ => Err(anyhow!("request to evaluate is invalid")),
         }?;
-        let adm_req: AdmissionRequest = serde_json::from_value(req_obj)?;
+        let adm_req: AdmissionRequest = serde_json::from_value(req_obj)
+            .map_err(|e| anyhow!("cannot build AdmissionRequest object from given input: {e}"))?;
         ValidateRequest::AdmissionRequest(adm_req)
     };
 


### PR DESCRIPTION
Due to recent changes, the AdmissionRequest validation is stricter. Some of our e2e test fixtures are missing required values, making the test fail (which is the right thing to do).

This commit improves the error message given when the AdmissionRequest object is failing the validation. This makes everything less cryptic.

Prior to this commit:

```console
kwctl run \
    -r test_data/ns_without_labels.json \
    --allow-context-aware \
    --replay-host-capabilities-interactions test_data/session_project_found.yml \
    annotated-policy.wasm
Error: missing field `group`
```

With this commit:

```console
kwctl run \
    -r test_data/ns_without_labels.json \
    --allow-context-aware \
    --replay-host-capabilities-interactions test_data/session_project_found.yml \
    annotated-policy.wasm
Error: cannot build AdmissionRequest object from given input: missing field `group`
```
