### PR TITLE
fix: Make Rego inventories ordered and deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,12 +369,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
@@ -485,14 +479,14 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.12.1#12f678594e30fc8f69747f272dd9130f9bfe127a"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.12.2#f43d8b2b9f21b4f9053058fc957649b8bbe7551e"
 dependencies = [
  "base64 0.21.5",
  "chrono",
  "chrono-tz",
  "gtmpl",
  "gtmpl_value",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "json-patch",
  "lazy_static",
  "regex",
@@ -2378,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.86.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8647c2211a9b480d910b155d573602c52cd5f646acecb06a03d594865dc4784"
+checksum = "e34392aea935145070dcd5b39a6dea689ac6534d7d117461316c3d157b1d0fc3"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2389,11 +2383,11 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.86.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8952521f3e8ce11920229e5f2965fef70525aecd9efc7b65e39bf9e2c6f66d"
+checksum = "7266548b9269d9fa19022620d706697e64f312fb2ba31b93e6986453fcc82c92"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.5",
  "bytes",
  "chrono",
  "either",
@@ -2425,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.86.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7608a0cd05dfa36167d2da982bb70f17feb5450f73ec601f6d428bbcf991c5b9"
+checksum = "b8321c315b96b59f59ef6b33f604b84b905ab8f9ff114a4f909d934c520227b1"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -3368,8 +3362,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.12.1"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.12.1#12f678594e30fc8f69747f272dd9130f9bfe127a"
+version = "0.12.2"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.12.2#f43d8b2b9f21b4f9053058fc957649b8bbe7551e"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -3378,7 +3372,7 @@ dependencies = [
  "chrono",
  "dns-lookup",
  "email_address",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "json-patch",
  "k8s-openapi",
  "kube",
@@ -3402,7 +3396,7 @@ dependencies = [
  "wapc",
  "wasi-cap-std-sync",
  "wasi-common",
- "wasmparser 0.115.0",
+ "wasmparser 0.118.0",
  "wasmtime",
  "wasmtime-provider",
  "wasmtime-wasi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 pulldown-cmark-mdcat = { version = "2.1.0", default-features = false, features = [
   "regex-fancy",
 ] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.12.1" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.12.2" }
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.9.3", default-features = false }
 regex = "1"

--- a/src/run.rs
+++ b/src/run.rs
@@ -9,8 +9,8 @@ use policy_evaluator::{
     policy_fetcher::{sources::Sources, verify::FulcioAndRekorData, PullDestination},
     policy_metadata::{ContextAwareResource, Metadata, PolicyType},
 };
+use std::collections::BTreeSet;
 use std::{
-    collections::HashSet,
     net::{Ipv4Addr, Ipv6Addr},
     path::Path,
 };
@@ -299,15 +299,15 @@ fn has_raw_policy_type(metadata: Option<&Metadata>) -> bool {
 fn compute_context_aware_resources(
     metadata: Option<&Metadata>,
     cfg: &PullAndRunSettings,
-) -> HashSet<ContextAwareResource> {
+) -> BTreeSet<ContextAwareResource> {
     match metadata {
         None => {
             info!("Policy is not annotated, access to Kubernetes resources is not allowed");
-            HashSet::new()
+            BTreeSet::new()
         }
         Some(metadata) => {
             if metadata.context_aware_resources.is_empty() {
-                return HashSet::new();
+                return BTreeSet::new();
             }
 
             if cfg.allow_context_aware_resources {
@@ -317,7 +317,7 @@ fn compute_context_aware_resources(
                 warn!("Policy requires access to Kubernetes resources at evaluation time. During this execution the access to Kubernetes resources is denied. This can cause the policy to not behave properly");
                 warn!("Carefully review which types of Kubernetes resources the policy needs via the `inspect` command, then run the policy using the `--allow-context-aware` flag.");
 
-                HashSet::new()
+                BTreeSet::new()
             }
         }
     }
@@ -585,7 +585,8 @@ mod tests {
 
     #[test]
     fn prevent_access_to_kubernetes_resources_when_allow_context_aware_resources_is_disabled() {
-        let mut context_aware_resources = HashSet::new();
+        let mut context_aware_resources = BTreeSet::new();
+
         context_aware_resources.insert(ContextAwareResource {
             api_version: "v1".to_string(),
             kind: "Pod".to_string(),
@@ -607,7 +608,7 @@ mod tests {
 
     #[test]
     fn allow_access_to_kubernetes_resources_when_allow_context_aware_resources_is_enabled() {
-        let mut context_aware_resources = HashSet::new();
+        let mut context_aware_resources = BTreeSet::new();
         context_aware_resources.insert(ContextAwareResource {
             api_version: "v1".to_string(),
             kind: "Pod".to_string(),

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use policy_evaluator::validator::Validate;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
 use std::fs::{self, File};
 use std::path::PathBuf;
@@ -58,14 +58,14 @@ struct ClusterAdmissionPolicySpec {
     #[serde(skip_serializing_if = "is_true")]
     background_audit: bool,
     #[serde(skip_serializing_if = "is_empty")]
-    context_aware_resources: HashSet<ContextAwareResource>,
+    context_aware_resources: BTreeSet<ContextAwareResource>,
 }
 
 fn is_true(b: &bool) -> bool {
     *b
 }
 
-fn is_empty(h: &HashSet<ContextAwareResource>) -> bool {
+fn is_empty(h: &BTreeSet<ContextAwareResource>) -> bool {
     h.is_empty()
 }
 
@@ -196,7 +196,7 @@ fn generate_yaml_resource(
                     warn!("Carefully review which types of Kubernetes resources the policy needs via the `inspect` command an populate the `contextAwareResources` accordingly.");
                     warn!("Otherwise, invoke the `scaffold` command using the `--allow-context-aware` flag.");
 
-                    scaffold_data.metadata.context_aware_resources = HashSet::new();
+                    scaffold_data.metadata.context_aware_resources = BTreeSet::new();
                 }
             }
 
@@ -331,7 +331,6 @@ pub(crate) fn artifacthub(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
 
     fn mock_metadata_with_no_annotations() -> Metadata {
         Metadata {
@@ -340,7 +339,7 @@ mod tests {
             annotations: None,
             mutating: false,
             background_audit: true,
-            context_aware_resources: HashSet::new(),
+            context_aware_resources: BTreeSet::new(),
             execution_mode: Default::default(),
             policy_type: Default::default(),
             minimum_kubewarden_version: None,
@@ -357,7 +356,7 @@ mod tests {
             )])),
             mutating: false,
             background_audit: true,
-            context_aware_resources: HashSet::new(),
+            context_aware_resources: BTreeSet::new(),
             execution_mode: Default::default(),
             policy_type: Default::default(),
             minimum_kubewarden_version: None,
@@ -384,7 +383,7 @@ mod tests {
             ])),
             mutating: false,
             background_audit: true,
-            context_aware_resources: HashSet::new(),
+            context_aware_resources: BTreeSet::new(),
             execution_mode: Default::default(),
             policy_type: Default::default(),
             minimum_kubewarden_version: None,
@@ -529,7 +528,7 @@ mod tests {
 
     #[test]
     fn scaffold_cluster_admission_policy_with_context_aware_enabled() {
-        let mut context_aware_resources: HashSet<ContextAwareResource> = HashSet::new();
+        let mut context_aware_resources: BTreeSet<ContextAwareResource> = BTreeSet::new();
         context_aware_resources.insert(ContextAwareResource {
             api_version: "v1".to_string(),
             kind: "Pod".to_string(),
@@ -559,7 +558,7 @@ mod tests {
 
     #[test]
     fn scaffold_cluster_admission_policy_with_context_aware_disabled() {
-        let mut context_aware_resources: HashSet<ContextAwareResource> = HashSet::new();
+        let mut context_aware_resources: BTreeSet<ContextAwareResource> = BTreeSet::new();
         context_aware_resources.insert(ContextAwareResource {
             api_version: "v1".to_string(),
             kind: "Pod".to_string(),


### PR DESCRIPTION
## Description

Ensure the rego inventory of Kubernetes resources is built in a deterministic way. Without that, a `kwctl run` outcome might fail without a valid reason.

This issue was reported by @brunorene

This depends on https://github.com/kubewarden/policy-evaluator/pull/389