### PR TITLE
Tag 1.9.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.9.0"
+version = "1.9.1"
 authors = ["Kubewarden Developers <kubewarden@suse.de>"]
 edition = "2021"
 


### PR DESCRIPTION
- fix: Make Rego inventories ordered and deterministic (#655)
- Update many deps
