### PR TITLE
ci: Fix release job by uploading artifacts only once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Upload kwctl air gap scripts
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        if: matrix.targetarch == 'x86_64' # only upload the scripts once
         with:
           name: kwctl-airgap-scripts
           path: |


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

If not, both the workflow run of the job `build-linux-binaries` for `aarch64` and `x86_64` try to upload the same file, which results in error.

See:  https://github.com/kubewarden/kwctl/actions/runs/7460505456/job/20298712321
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Untested.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
