### PR TITLE
improve inspect cmd

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -384,6 +384,10 @@ fn subcommand_inspect() -> Command {
             .long("docker-config-json-path")
             .value_name("PATH")
             .help("Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details"),
+        Arg::new("show-signatures")
+            .long("show-signatures")
+            .num_args(0)
+            .help("Show sigstore signatures"),
     ];
     args.sort_by(|a, b| a.get_id().cmp(b.get_id()));
     args.push(

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -48,9 +48,6 @@ pub(crate) async fn inspect(
     match signatures {
         Ok(signatures) => {
             if let Some(signatures) = signatures {
-                println!();
-                println!("Sigstore signatures");
-                println!();
                 let sigstore_printer = SignaturesPrinter::from(&output);
                 sigstore_printer.print(&signatures);
             }
@@ -309,6 +306,10 @@ impl SignaturesPrinter {
                 }
             }
             SignaturesPrinter::Pretty => {
+                println!();
+                println!("Sigstore signatures");
+                println!();
+
                 for layer in &signatures.layers {
                     let mut table = Table::new();
                     table.set_format(FormatBuilder::new().padding(0, 1).build());

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,8 +319,12 @@ async fn main() -> Result<()> {
                     matches.get_one::<String>("output").map(|s| s.as_str()),
                 )?;
                 let sources = remote_server_options(matches)?;
-
-                inspect::inspect(uri_or_sha_prefix, output, sources, no_color).await?;
+                let no_signatures = !matches
+                    .get_one::<bool>("show-signatures")
+                    .unwrap_or(&false)
+                    .to_owned();
+                inspect::inspect(uri_or_sha_prefix, output, sources, no_color, no_signatures)
+                    .await?;
             };
             Ok(())
         }


### PR DESCRIPTION
- fix: do not break yaml output of `inspect` (fixes https://github.com/kubewarden/kwctl/issues/659)
- feat: by default do not show signagures inside of inspect output
