### PR TITLE
chore: bumps version in Cargo.toml to v1.11.0-rc3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.11.0-rc2"
+version = "1.11.0-rc3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.11.0-rc2"
+version = "1.11.0-rc3"
 authors = ["Kubewarden Developers <kubewarden@suse.de>"]
 edition = "2021"
 


### PR DESCRIPTION
## Description

Updates the version in the Cargo.toml file to v1.11.0-rc3.