### PR TITLE
ci: Build release binaries for `main`, `feat-*` branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: kwctl build
 on:
   workflow_call:
+  push:
+    branches:
+      - "main"
+      - "feat-**"
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Build release binaries for `main`, `feat-*` branches.

I believe this is the correct way of triggering these kind of builds for main. The release workflow doesn't do anything for builds, just depends and workflow_calls the build workflow.

The resulting binaries are available to download from the job run.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
See the run for main on my fork: https://github.com/viccuad/kwctl/actions/runs/8690166643/job/23829437135
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
