### PR TITLE
feat: scaffold KW policy from Kubernetes ValidatingAdmissionPolicy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.17.7#cd093d73ebd17ad5390ef94e70940bc79daae798"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.0#2b2f7a8a4637071d03c40ea92c358ddfd1121167"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3861,8 +3861,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.17.7"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.17.7#cd093d73ebd17ad5390ef94e70940bc79daae798"
+version = "0.18.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.0#2b2f7a8a4637071d03c40ea92c358ddfd1121167"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3894,7 +3894,7 @@ dependencies = [
  "validator",
  "wapc",
  "wasi-common",
- "wasmparser 0.210.0",
+ "wasmparser 0.211.1",
  "wasmtime",
  "wasmtime-provider",
  "wasmtime-wasi",
@@ -6152,6 +6152,20 @@ name = "wasmparser"
 version = "0.210.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7bbcd21e7581619d9f6ca00f8c4f08f1cacfe58bf63f83af57cd0476f1026f5"
+dependencies = [
+ "ahash 0.8.11",
+ "bitflags 2.5.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.211.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3189cc8a91f547390e2f043ca3b3e3fe0892f7d581767fd4e4b7f3dc3fe8e561"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ pem = "3"
 pulldown-cmark-mdcat = { version = "2.1.2", default-features = false, features = [
   "regex-fancy",
 ] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.17.7" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.0" }
 rustls-pki-types = { version = "1", features = ["alloc"] }
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.9.3", default-features = false }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -465,6 +465,27 @@ fn subcommand_scaffold() -> Command {
             .help("Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory."),
     );
 
+    let mut vap_args = vec![
+        Arg::new("cel-policy")
+            .long("cel-policy")
+            .value_name("URI")
+            .default_value("ghcr.io/kubewarden/policies/cel-policy:latest")
+            .help("The CEL policy module to use"),
+        Arg::new("policy")
+            .long("policy")
+            .short('p')
+            .required(true)
+            .value_name("VALIDATING-ADMISSION-POLICY.yaml")
+            .help("The file containining the ValidatingAdmissionPolicy definition"),
+        Arg::new("binding")
+            .long("binding")
+            .short('b')
+            .required(true)
+            .value_name("VALIDATING-ADMISSION-POLICY-BINDING.yaml")
+            .help("The file containining the ValidatingAdmissionPolicyBinding definition"),
+    ];
+    vap_args.sort_by(|a, b| a.get_id().cmp(b.get_id()));
+
     let mut subcommands = vec![
         Command::new("verification-config")
             .about("Output a default Sigstore verification configuration file"),
@@ -474,6 +495,9 @@ fn subcommand_scaffold() -> Command {
         Command::new("manifest")
             .about("Output a Kubernetes resource manifest")
             .args(manifest_args),
+        Command::new("vap")
+            .about("Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`")
+            .args(vap_args),
     ];
     subcommands.sort_by(|a, b| a.get_name().cmp(b.get_name()));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,6 +394,20 @@ async fn main() -> Result<()> {
                     )?;
                 };
             }
+            if let Some(matches) = matches.subcommand_matches("scaffold") {
+                if let Some(matches) = matches.subcommand_matches("vap") {
+                    let cel_policy_uri = matches.get_one::<String>("cel-policy").unwrap();
+                    let vap_file: PathBuf = matches.get_one::<String>("policy").unwrap().into();
+                    let vap_binding_file: PathBuf =
+                        matches.get_one::<String>("binding").unwrap().into();
+
+                    scaffold::vap(
+                        cel_policy_uri.as_str(),
+                        vap_file.as_path(),
+                        vap_binding_file.as_path(),
+                    )?;
+                };
+            }
             Ok(())
         }
         Some("completions") => {

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -1,12 +1,17 @@
 use anyhow::{anyhow, Result};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-use policy_evaluator::validator::Validate;
+use k8s_openapi::api::admissionregistration::v1::{
+    ValidatingAdmissionPolicy, ValidatingAdmissionPolicyBinding,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use policy_evaluator::{policy_fetcher::oci_distribution::Reference, validator::Validate};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::convert::TryFrom;
-use std::fs::{self, File};
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    convert::TryFrom,
+    fs::{self, File},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use time::OffsetDateTime;
 use tracing::warn;
 
@@ -46,7 +51,7 @@ struct ClusterAdmissionPolicy {
     spec: ClusterAdmissionPolicySpec,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct ClusterAdmissionPolicySpec {
     module: String,
@@ -57,16 +62,22 @@ struct ClusterAdmissionPolicySpec {
     // This is needed as a temporary fix for https://github.com/kubewarden/kubewarden-controller/issues/395
     #[serde(skip_serializing_if = "is_true")]
     background_audit: bool,
-    #[serde(skip_serializing_if = "is_empty")]
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
     context_aware_resources: BTreeSet<ContextAwareResource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failure_policy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    match_policy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    namespace_selector: Option<LabelSelector>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    object_selector: Option<LabelSelector>,
 }
 
 fn is_true(b: &bool) -> bool {
     *b
-}
-
-fn is_empty(h: &BTreeSet<ContextAwareResource>) -> bool {
-    h.is_empty()
 }
 
 impl TryFrom<ScaffoldPolicyData> for ClusterAdmissionPolicy {
@@ -85,6 +96,7 @@ impl TryFrom<ScaffoldPolicyData> for ClusterAdmissionPolicy {
                 mutating: data.metadata.mutating,
                 background_audit: data.metadata.background_audit,
                 context_aware_resources: data.metadata.context_aware_resources,
+                ..Default::default()
             },
         })
     }
@@ -328,9 +340,137 @@ pub(crate) fn artifacthub(
     ))
 }
 
+pub(crate) fn vap(cel_policy_module: &str, vap_path: &Path, binding_path: &Path) -> Result<()> {
+    let vap_file = File::open(vap_path)
+        .map_err(|e| anyhow!("cannot open {}: #{e}", vap_path.to_str().unwrap()))?;
+    let binding_file = File::open(binding_path)
+        .map_err(|e| anyhow!("cannot open {}: #{e}", binding_path.to_str().unwrap()))?;
+
+    let vap: ValidatingAdmissionPolicy = serde_yaml::from_reader(vap_file)
+        .map_err(|e| anyhow!("cannot convert given data into a ValidatingAdmissionPolicy: #{e}"))?;
+    let vap_binding: ValidatingAdmissionPolicyBinding = serde_yaml::from_reader(binding_file)
+        .map_err(|e| {
+            anyhow!("cannot convert given data into a ValidatingAdmissionPolicyBinding: #{e}")
+        })?;
+
+    match cel_policy_module.parse::<Reference>() {
+        Ok(cel_policy_ref) => match cel_policy_ref.tag() {
+            None | Some("latest") => {
+                warn!(
+                    "Using the 'latest' version of the CEL policy could lead to unexpected behavior. It is recommended to use a specific version to avoid breaking changes."
+                );
+            }
+            _ => {}
+        },
+        Err(_) => {
+            warn!("The CEL policy module specified is not a valid OCI reference");
+        }
+    }
+
+    let cluster_admission_policy =
+        convert_vap_to_cluster_admission_policy(cel_policy_module, vap, vap_binding)?;
+
+    serde_yaml::to_writer(std::io::stdout(), &cluster_admission_policy)?;
+
+    Ok(())
+}
+
+fn convert_vap_to_cluster_admission_policy(
+    cel_policy_module: &str,
+    vap: ValidatingAdmissionPolicy,
+    vap_binding: ValidatingAdmissionPolicyBinding,
+) -> anyhow::Result<ClusterAdmissionPolicy> {
+    let vap_spec = vap.spec.unwrap_or_default();
+    if vap_spec.audit_annotations.is_some() {
+        warn!("auditAnnotations are not supported by Kubewarden's CEL policy yet. They will be ignored.");
+    }
+    if vap_spec.match_conditions.is_some() {
+        warn!("matchConditions are not supported by Kubewarden's CEL policy yet. They will be ignored.");
+    }
+    if vap_spec.param_kind.is_some() {
+        // It's not safe to skip this, the policy will definitely not work.
+        return Err(anyhow!(
+            "paramKind is not supported by Kubewarden's CEL policy yet"
+        ));
+    }
+
+    let mut settings = serde_yaml::Mapping::new();
+
+    // migrate CEL variables
+    if let Some(vap_variables) = vap_spec.variables {
+        let vap_variables: Vec<serde_yaml::Value> = vap_variables
+            .iter()
+            .map(|v| serde_yaml::to_value(v).expect("cannot convert VAP variable to YAML"))
+            .collect();
+        settings.insert("variables".into(), vap_variables.into());
+    }
+
+    // migrate CEL validations
+    if let Some(vap_validations) = vap_spec.validations {
+        let kw_cel_validations: Vec<serde_yaml::Value> = vap_validations
+            .iter()
+            .map(|v| serde_yaml::to_value(v).expect("cannot convert VAP validation to YAML"))
+            .collect();
+        settings.insert("validations".into(), kw_cel_validations.into());
+    }
+
+    // VAP specifies the namespace selector inside of the binding
+    let namespace_selector = vap_binding
+        .spec
+        .unwrap_or_default()
+        .match_resources
+        .unwrap_or_default()
+        .namespace_selector;
+
+    // VAP rules are specified inside of the VAP object
+    let vap_match_constraints = vap_spec.match_constraints.unwrap_or_default();
+    let match_policy = vap_match_constraints.match_policy;
+    let rules = vap_match_constraints
+        .resource_rules
+        .unwrap_or_default()
+        .iter()
+        .map(Rule::try_from)
+        .collect::<Result<Vec<Rule>, &'static str>>()
+        .map_err(|e| anyhow!("error converting VAP matchConstraints into rules: {e}"))?;
+
+    // migrate VAP
+    let cluster_admission_policy = ClusterAdmissionPolicy {
+        api_version: "policies.kubewarden.io/v1".to_string(),
+        kind: "ClusterAdmissionPolicy".to_string(),
+        metadata: vap_binding.metadata,
+        spec: ClusterAdmissionPolicySpec {
+            module: cel_policy_module.to_string(),
+            namespace_selector,
+            match_policy,
+            rules,
+            object_selector: vap_match_constraints.object_selector,
+            mutating: false,
+            background_audit: true,
+            context_aware_resources: BTreeSet::new(),
+            failure_policy: vap_spec.failure_policy,
+            mode: None, // VAP policies are always in protect mode, which is the default for KW
+            settings,
+        },
+    };
+
+    Ok(cluster_admission_policy)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::*;
+
+    pub fn test_data(path: &str) -> String {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("data")
+            .join(path)
+            .to_string_lossy()
+            .to_string()
+    }
+
+    const CEL_POLICY_MODULE: &str = "ghcr.io/kubewarden/policies/cel-policy:latest";
 
     fn mock_metadata_with_no_annotations() -> Metadata {
         Metadata {
@@ -584,5 +724,95 @@ mod tests {
         let spec = resource.get("spec").expect("cannot get `Spec`");
         let context_aware_resources = spec.get("contextAwareResources");
         assert!(context_aware_resources.is_none());
+    }
+
+    #[rstest]
+    #[case::vap_without_variables("vap/vap-without-variables.yml", "vap/vap-binding.yml", false)]
+    #[case::vap_with_variables("vap/vap-with-variables.yml", "vap/vap-binding.yml", true)]
+    fn from_vap_to_cluster_admission_policy(
+        #[case] vap_yaml_path: &str,
+        #[case] vap_binding_yaml_path: &str,
+        #[case] has_variables: bool,
+    ) {
+        let yaml_file = File::open(test_data(vap_yaml_path)).unwrap();
+        let vap: ValidatingAdmissionPolicy = serde_yaml::from_reader(yaml_file).unwrap();
+
+        let expected_validations =
+            serde_yaml::to_value(vap.clone().spec.unwrap().validations.unwrap()).unwrap();
+        let expected_rules = vap
+            .clone()
+            .spec
+            .unwrap()
+            .match_constraints
+            .unwrap()
+            .resource_rules
+            .unwrap()
+            .iter()
+            .map(Rule::try_from)
+            .collect::<Result<Vec<Rule>, &str>>()
+            .unwrap();
+
+        let yaml_file = File::open(test_data(vap_binding_yaml_path)).unwrap();
+        let vap_binding: ValidatingAdmissionPolicyBinding =
+            serde_yaml::from_reader(yaml_file).unwrap();
+
+        let cluster_admission_policy = convert_vap_to_cluster_admission_policy(
+            CEL_POLICY_MODULE,
+            vap.clone(),
+            vap_binding.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(CEL_POLICY_MODULE, cluster_admission_policy.spec.module);
+        assert!(!cluster_admission_policy.spec.mutating);
+        assert_eq!(cluster_admission_policy.spec.rules, expected_rules);
+        assert!(cluster_admission_policy.spec.background_audit);
+        assert!(cluster_admission_policy
+            .spec
+            .context_aware_resources
+            .is_empty());
+        assert_eq!(
+            vap.clone().spec.unwrap().failure_policy,
+            cluster_admission_policy.spec.failure_policy
+        );
+        assert!(cluster_admission_policy.spec.mode.is_none());
+        assert_eq!(
+            vap.clone()
+                .spec
+                .unwrap()
+                .match_constraints
+                .unwrap()
+                .match_policy,
+            cluster_admission_policy.spec.match_policy
+        );
+        assert_eq!(
+            vap_binding
+                .clone()
+                .spec
+                .unwrap()
+                .match_resources
+                .unwrap()
+                .namespace_selector,
+            cluster_admission_policy.spec.namespace_selector
+        );
+        assert!(cluster_admission_policy.spec.object_selector.is_none());
+        assert_eq!(
+            expected_validations,
+            cluster_admission_policy.spec.settings["validations"]
+        );
+
+        if has_variables {
+            let expected_variables =
+                serde_yaml::to_value(vap.clone().spec.unwrap().variables.unwrap()).unwrap();
+            assert_eq!(
+                expected_variables,
+                cluster_admission_policy.spec.settings["variables"]
+            );
+        } else {
+            assert!(!cluster_admission_policy
+                .spec
+                .settings
+                .contains_key("variables"));
+        }
     }
 }

--- a/tests/data/vap/vap-binding.yml
+++ b/tests/data/vap/vap-binding.yml
@@ -1,0 +1,11 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "kw-scaffold-demo"
+spec:
+  policyName: "vap-test"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: default

--- a/tests/data/vap/vap-with-variables.yml
+++ b/tests/data/vap/vap-with-variables.yml
@@ -1,0 +1,19 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "force-liveness-probe"
+spec:
+  failurePolicy: Fail
+  variables:
+    - name: containers_without_liveness_probe
+      expression: "object.spec.template.spec.containers.filter(c, !has(c.livenessProbe)).map(c, c.name)"
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["apps"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["deployments"]
+  validations:
+    - expression: "size(variables.containers_without_liveness_probe) == 0"
+      messageExpression: "'These containers are missing a liveness probe: ' + variables.containers_without_liveness_probe.join(' ')"
+      reason: Invalid

--- a/tests/data/vap/vap-without-variables.yml
+++ b/tests/data/vap/vap-without-variables.yml
@@ -1,0 +1,19 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "vap-test"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["apps"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["deployments", "deployments/scale"]
+  validations:
+    - expression: "object.spec.replicas > 2"
+      message: "should have at least 2 replicas"
+    - expression: "object.spec.replicas <= 10"
+      message: "should have at most 5 replicas"
+    - expression: "object.spec.replicas % 2 != 0"
+      message: "should have an odd number of replicas"


### PR DESCRIPTION
Add the new `scaffold vap` subcommand. This allows to create a Kubewarden ClusterAdmissionPolicy starting from a Kubernetes ValidatingAdmissionPolicy.
