### PR TITLE
fix: improve error handling in settings validation.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -247,7 +247,15 @@ async fn main() -> Result<()> {
         Some("run") => {
             if let Some(matches) = matches.subcommand_matches("run") {
                 let pull_and_run_settings = parse_pull_and_run_settings(matches).await?;
-                run::pull_and_run(&pull_and_run_settings).await?;
+                run::pull_and_run(&pull_and_run_settings)
+                    .await
+                    .map_err(|e| {
+                        anyhow!(
+                            "Error running policy {}: {}",
+                            pull_and_run_settings.uri,
+                            e.to_string()
+                        )
+                    })?;
             }
             Ok(())
         }

--- a/src/run.rs
+++ b/src/run.rs
@@ -168,10 +168,9 @@ pub(crate) async fn pull_and_run(cfg: &PullAndRunSettings) -> Result<()> {
     // validate the settings given by the user
     let settings_validation_response = policy_evaluator.validate_settings(&run_env.policy_settings);
     if !settings_validation_response.valid {
-        println!("{}", serde_json::to_string(&settings_validation_response)?);
         return Err(anyhow!(
             "Provided settings are not valid: {:?}",
-            settings_validation_response.message
+            settings_validation_response.message.unwrap_or_default()
         ));
     }
 


### PR DESCRIPTION
## Description

When the policy settings validation failed, the error message printed twice in the console. This commit fix that by removing a where the error is printed once.

It's not possible to improve more the error message because the JSON shown in some error came from a string with the error message returned by the settings validator. It's not possible to kwctl to easily improve that without string manipulations.

Fix #801 

This is an example of an error message with this change:

```console
$ ./target/release/kwctl run --request-path pod_creation_signed.json --settings-path ./settings2.json registry://ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8             ✔ │ 9s │ 15:35:12 
Error: Error running policy registry://ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8: Provided settings are not valid: "Error invoking settings validation callback: GuestCallFailure(\"Error decoding validation payload {\\\"signatures\\\":{\\\"foo\\\":[{\\\"image\\\":\\\"demo.goharbor.io/testing/*\\\",\\\"pubKeys\\\":[\\\"-----BEGIN PUBLIC KEY-----\\\\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVIq8ZbAJYntgr/suvQFnuM/dbWiE\\\\noFRemT6fQeINVlxw9WGdBQiLVUmwPVclv07qscx3lEUQp/D8X3kBzqqWQw==\\\\n-----END PUBLIC KEY-----\\\\n\\\"]}]}}: Error(\\\"invalid type: map, expected a sequence\\\", line: 1, column: 14)\")"

```

@kubewarden/kubewarden-developers is this good enough for you? Do you have other suggestions?