### PR TITLE
chore: bump version to v1.14.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.14.0-rc1"
+version = "1.14.0-rc2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.14.0-rc1"
+version = "1.14.0-rc2"
 authors = ["Kubewarden Developers <kubewarden@suse.de>"]
 edition = "2021"
 


### PR DESCRIPTION
## Description

Bumps the kwctl version in the Cargo files to v1.14.0-rc2


