### PR TITLE
feat: allow `manifest` to pull a remote policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ dependencies = [
  "tar",
  "tempfile",
  "testcontainers",
+ "thiserror",
  "time",
  "tiny-bench",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ syntect = { version = "5.2", default-features = false, features = [
   "parsing",
 ] }
 tar = "0.4.40"
+thiserror = "1.0"
 tiny-bench = "0.3"
 tokio = { version = "^1.39.0", features = ["full"] }
 tracing = "0.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,8 +16,9 @@ Use the `info` command to display system information.
     };
 }
 
-fn subcommand_pull() -> Command {
-    let mut args = vec![
+// Minimum set of flags required to pull a policy from a registry
+fn pull_shared_flags() -> Vec<Arg> {
+    vec![
         Arg::new("docker-config-json-path")
             .long("docker-config-json-path")
             .value_name("DOCKER_CONFIG")
@@ -74,12 +75,16 @@ fn subcommand_pull() -> Command {
             .number_of_values(1)
             .value_name("VALUE")
             .help("GitHub repository expected in the certificates generated in CD pipelines"),
-        Arg::new("output-path")
-            .short('o')
-            .long("output-path")
-            .value_name("PATH")
-            .help("Output file. If not provided will be downloaded to the Kubewarden store"),
-    ];
+    ]
+}
+
+fn subcommand_pull() -> Command {
+    let mut args = pull_shared_flags();
+    args.extend_from_slice(&[Arg::new("output-path")
+        .short('o')
+        .long("output-path")
+        .value_name("PATH")
+        .help("Output file. If not provided will be downloaded to the Kubewarden store")]);
     args.sort_by(|a, b| a.get_id().cmp(b.get_id()));
     args.push(
         Arg::new("uri")
@@ -457,6 +462,8 @@ fn subcommand_scaffold() -> Command {
             .num_args(0)
             .help("Uses the policy metadata to define which Kubernetes resources can be accessed by the policy. Warning: review the list of resources carefully to avoid abuses. Disabled by default"),
     ];
+    // When scaffolding the manifest of a missing policy, we can pull it from a registry
+    manifest_args.extend_from_slice(&pull_shared_flags());
     manifest_args.sort_by(|a, b| a.get_id().cmp(b.get_id()));
     manifest_args.push(
         Arg::new("uri_or_sha_prefix")

--- a/src/scaffold/manifest.rs
+++ b/src/scaffold/manifest.rs
@@ -122,7 +122,7 @@ pub(crate) fn manifest(
     policy_title: Option<&str>,
     allow_context_aware_resources: bool,
 ) -> Result<()> {
-    let uri = crate::utils::map_path_to_uri(uri_or_sha_prefix)?;
+    let uri = crate::utils::get_uri(&uri_or_sha_prefix.to_owned())?;
     let wasm_path = crate::utils::wasm_path(&uri)?;
 
     let metadata = Metadata::from_path(&wasm_path)?

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -377,10 +377,14 @@ fn test_push() {
         .stdout(contains("my-pod-priviliged-policy:v0.1.10"));
 }
 
-#[test]
-fn test_scaffold_manifest() {
+#[rstest]
+#[case::pull_policies_before_scaffold(true)]
+#[case::pull_policies_on_demand(false)]
+fn test_scaffold_manifest(#[case] pull_policies_before: bool) {
     let tempdir = tempdir().unwrap();
-    pull_policies(tempdir.path(), POLICIES);
+    if pull_policies_before {
+        pull_policies(tempdir.path(), POLICIES);
+    }
 
     let mut cmd = setup_command(tempdir.path());
     cmd.arg("scaffold")


### PR DESCRIPTION
## Description

Updates the manifest command to pull the policy if it is not in the local storage.

Fix #844 