### PR TITLE
chore: bumps v1.15.0-rc1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.2#e363148a59cf3de6ae29b55d2a845ac3ed6f4e0e"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.3#d4fee6b2b4a04c98a4573dcf2eccfa156422b0dd"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -493,20 +493,20 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8466736fe5dbcaf8b8ee24f9bbefe43c884dc3e9ff7178da70f55bffca1133c"
+checksum = "b4d73155ae6b28cf5de4cfc29aeb02b8a1c6dab883cb015d15cd514e42766846"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
- "cached_proc_macro 0.22.0",
+ "cached_proc_macro 0.23.0",
  "cached_proc_macro_types",
  "futures",
  "hashbrown 0.14.5",
- "instant",
  "once_cell",
  "thiserror",
  "tokio",
+ "web-time",
 ]
 
 [[package]]
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f32e012222055211b70f5b0601f951f84523410a0e65c81f2744a6042450d"
+checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.92.1"
+version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231c5a5392d9e2a9b0d923199760d3f1dd73b95288f2871d16c7c90ba4954506"
+checksum = "0365920075af1a2d23619c1ca801c492f2400157de42627f041a061716e76416"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.92.1"
+version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4bf54135062ff60e2a0dfb3e7a9c8e931fc4a535b4d6bd561e0a1371321c61"
+checksum = "d81336eb3a5b10a40c97a5a97ad66622e92bad942ce05ee789edd730aa4f8603"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2601,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.92.1"
+version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fb9bd8141cbc0fe6b0d9112d371679b4cb607b45c31dd68d92e40864a12975"
+checksum = "cce373a74d787d439063cdefab0f3672860bd7bac01a38e39019177e764a0fe6"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2617,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.92.1"
+version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7eb2fb986f81770eb55ec7f857e197019b31b38768d2410f6c1046ffac34225"
+checksum = "3b84733c0fed6085c9210b43ffb96248676c1e800d0ba38d15043275a792ffa4"
 dependencies = [
  "ahash 0.8.11",
  "async-broadcast",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.14.0"
+version = "1.15.0-rc1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3690,13 +3690,13 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.18.2"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.2#e363148a59cf3de6ae29b55d2a845ac3ed6f4e0e"
+version = "0.18.3"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.3#d4fee6b2b4a04c98a4573dcf2eccfa156422b0dd"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "burrego",
- "cached 0.52.0",
+ "cached 0.53.1",
  "chrono",
  "dns-lookup",
  "email_address",
@@ -6356,6 +6356,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kwctl"
 description = "Tool to manage Kubewarden policies"
-version = "1.14.0"
+version = "1.15.0-rc1"
 authors = ["Kubewarden Developers <kubewarden@suse.de>"]
 edition = "2021"
 
@@ -23,7 +23,7 @@ pem = "3"
 pulldown-cmark-mdcat = { version = "2.2.0", default-features = false, features = [
   "regex-fancy",
 ] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.2" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.3" }
 rustls-pki-types = { version = "1", features = ["alloc"] }
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.9.3", default-features = false }


### PR DESCRIPTION
## Description

Bumps the version in the Cargo files to v1.15.0-rc1
