### PR TITLE
chore(deps): bump policy-evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.4#4fcf2c475488a07156975ec52db697ce45ec3372"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.5#3cd66b932b199037e677e3e204d4d9742e23edc8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3143,6 +3143,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-client"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560faeb9396a5bae11b141bed3cec8bf9242e5bfec17d0f48feeeab0f879ca35"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "olpc-cjson 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
 name = "oci-distribution"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,8 +3691,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.18.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.4#4fcf2c475488a07156975ec52db697ce45ec3372"
+version = "0.18.5"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.5#3cd66b932b199037e677e3e204d4d9742e23edc8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3707,8 +3732,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.8.8"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.8.8#0f31d41442390c87d55b4cb24d6249ae962d3110"
+version = "0.8.9"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.8.9#f33a196e5afe91f280657938d2fe41d9316dfdcc"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3716,7 +3741,7 @@ dependencies = [
  "directories",
  "docker_credential",
  "lazy_static",
- "oci-distribution",
+ "oci-client",
  "path-slash",
  "pem",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ pem = "3"
 pulldown-cmark-mdcat = { version = "2.2.0", default-features = false, features = [
   "regex-fancy",
 ] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.4" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.5" }
 rustls-pki-types = { version = "1", features = ["alloc"] }
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.9.3", default-features = false }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -4,7 +4,7 @@ use policy_evaluator::{
     constants::*,
     policy_evaluator::PolicyExecutionMode,
     policy_fetcher::{
-        oci_distribution::{
+        oci_client::{
             manifest::{OciImageManifest, OciManifest},
             secrets::RegistryAuth,
         },

--- a/src/scaffold/vap.rs
+++ b/src/scaffold/vap.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use k8s_openapi::api::admissionregistration::v1::{
     ValidatingAdmissionPolicy, ValidatingAdmissionPolicyBinding,
 };
-use policy_evaluator::{policy_fetcher::oci_distribution::Reference, policy_metadata::Rule};
+use policy_evaluator::{policy_fetcher::oci_client::Reference, policy_metadata::Rule};
 use std::{collections::BTreeSet, convert::TryFrom, fs::File, path::Path};
 use tracing::warn;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use policy_evaluator::policy_evaluator::PolicyExecutionMode;
-use policy_evaluator::policy_fetcher::oci_distribution::Reference;
+use policy_evaluator::policy_fetcher::oci_client::Reference;
 use policy_evaluator::policy_fetcher::store::{errors::StoreError, Store};
 use regex::Regex;
 use serde_json::json;


### PR DESCRIPTION
The `oci-distribution` crate has been renamed to `oci-client`
