### PR TITLE
chore: update cargo audit ignore list

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,4 +14,6 @@ ignore = [
   "RUSTSEC-2023-0081", # This is about `safemem` being unmaintained.
   # This is a transitive dependency of syntect. This bug is tracked upstream inside of
   # https://github.com/trishume/syntect/issues/521
+  "RUSTSEC-2024-0370", # This is a warning about `proc-macro-errors` being unmaintained. It's a transitive dependency of `sigstore` and `oci-spec`.
+  "RUSTSEC-2023-0055", # This is a warning about `lexical` having multiple soundness issues. It's a transitive dependency of `sigstore`.
 ]


### PR DESCRIPTION
A bunch of warnings have popped up. There's nothing we can do about them and they basically no impact on us.

- "RUSTSEC-2024-0370": This is a warning about `proc-macro-errors` being unmaintained. It's a transitive dependency of `sigstore` and `oci-spec`.
- "RUSTSEC-2023-0055": This is a warning about `lexical` having multiple soundness issues. It's a transitive dependency of `sigstore`.
