### PR TITLE
Revert "ci: don't generate coverage for e2e tests"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       - uses: kubewarden/github-actions/tarpaulin-install@d94509d260ee11a92b4f65bc0acd297feec24d7f # v3.3.5
+
       - name: Generate unit-tests coverage
         run: make coverage-unit-tests
+
       - name: Upload unit-tests coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         env:
@@ -90,17 +94,19 @@ jobs:
           flags: unit-tests
           verbose: true
       - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-      # - name: Generate e2e-tests coverage
-      #   run: make coverage-e2e-tests
-      # - name: Upload e2e-tests coverage to Codecov
-      #   uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
-      #   env:
-      #     CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-      #   with:
-      #     name: e2e-tests
-      #     directory: coverage/e2e-tests
-      #     flags: e2e-tests
-      #     verbose: true
+
+      - name: Generate e2e-tests coverage
+        run: make coverage-e2e-tests
+
+      - name: Upload e2e-tests coverage to Codecov
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        with:
+          name: e2e-tests
+          directory: coverage/e2e-tests
+          flags: e2e-tests
+          verbose: true
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
## Description

This reverts commit bbe9ae3dfb48f4aab75b1936f58cb2589a26cca0. As far as I can see we disable it during the issues with sigstore. Now, we can re enabled it! ;)

Fix #852 