### PR TITLE
Ensure SLSA Lvl 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,17 +52,6 @@ jobs:
         with:
           subject-path: kwctl-linux-${{ matrix.targetarch }}
 
-      - run: |
-          mv \
-            ${{ steps.attestations.outputs.bundle-path }} \
-            kwctl-linux-${{ matrix.targetarch }}.attestation.sigstore.json
-
-      - name: Upload attestations
-        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4.4.1
-        with:
-          path: kwctl-linux-${{ matrix.targetarch }}.attestation.sigstore.json
-          name: kwctl-linux-${{ matrix.targetarch }}.attestation.sigstore.json
-
       - name: Sign kwctl
         run: |
           cosign sign-blob --yes kwctl-linux-${{ matrix.targetarch }} --output-certificate kwctl-linux-${{ matrix.targetarch}}.pem --output-signature kwctl-linux-${{ matrix.targetarch }}.sig
@@ -155,17 +144,6 @@ jobs:
         with:
           subject-path: kwctl-darwin-${{ matrix.targetarch }}
 
-      - run: |
-          mv \
-            ${{ steps.attestations.outputs.bundle-path }} \
-            kwctl-darwin-${{ matrix.targetarch }}.attestation.sigstore.json
-
-      - name: Upload attestations
-        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4.4.1
-        with:
-          path: kwctl-darwin-${{ matrix.targetarch }}.attestation.sigstore.json
-          name: kwctl-darwin-${{ matrix.targetarch }}.attestation.sigstore.json
-
       - name: Sign kwctl
         run: cosign sign-blob --yes kwctl-darwin-${{ matrix.targetarch }} --output-certificate kwctl-darwin-${{ matrix.targetarch }}.pem --output-signature kwctl-darwin-${{ matrix.targetarch }}.sig
 
@@ -251,15 +229,6 @@ jobs:
         id: attestations
         with:
           subject-path: kwctl-windows-${{ matrix.targetarch }}.exe
-
-      - run: |
-          move ${{ steps.attestations.outputs.bundle-path }} kwctl-windows-${{ matrix.targetarch }}.exe.attestation.sigstore.json
-
-      - name: Upload attestations
-        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4.4.1
-        with:
-          path: kwctl-windows-${{ matrix.targetarch }}.exe.attestation.sigstore.json
-          name: kwctl-windows-${{ matrix.targetarch }}.exe.attestation.sigstore.json
 
       - name: Sign kwctl
         run: cosign sign-blob --yes kwctl-windows-x86_64.exe --output-certificate kwctl-windows-x86_64.pem --output-signature kwctl-windows-x86_64.sig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,9 @@ jobs:
         targetarch:
           - aarch64
           - x86_64
-
     permissions:
-      packages: write
       id-token: write
-
+      attestations: write
     steps:
       - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
@@ -42,9 +40,31 @@ jobs:
           command: build
           args: --release --target ${{matrix.targetarch}}-unknown-linux-musl
 
+      - run: mv target/${{ matrix.targetarch }}-unknown-linux-musl/release/kwctl kwctl-linux-${{ matrix.targetarch }}
+
+      - name: Smoke test build
+        if: matrix.targetarch == 'x86_64'
+        run: ./kwctl-linux-x86_64 --help
+
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v1
+        id: attestations
+        with:
+          subject-path: kwctl-linux-${{ matrix.targetarch }}
+
+      - run: |
+          mv \
+            ${{ steps.attestations.outputs.bundle-path }} \
+            kwctl-linux-${{ matrix.targetarch }}.attestation.sigstore.json
+
+      - name: Upload attestations
+        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4.4.1
+        with:
+          path: kwctl-linux-${{ matrix.targetarch }}.attestation.sigstore.json
+          name: kwctl-linux-${{ matrix.targetarch }}.attestation.sigstore.json
+
       - name: Sign kwctl
         run: |
-          mv target/${{ matrix.targetarch }}-unknown-linux-musl/release/kwctl kwctl-linux-${{ matrix.targetarch }}
           cosign sign-blob --yes kwctl-linux-${{ matrix.targetarch }} --output-certificate kwctl-linux-${{ matrix.targetarch}}.pem --output-signature kwctl-linux-${{ matrix.targetarch }}.sig
 
       - run: zip -j9 kwctl-linux-${{ matrix.targetarch }}.zip kwctl-linux-${{ matrix.targetarch }} kwctl-linux-${{ matrix.targetarch }}.sig kwctl-linux-${{ matrix.targetarch }}.pem
@@ -102,6 +122,7 @@ jobs:
     runs-on: macos-latest
     permissions:
       id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
@@ -127,6 +148,23 @@ jobs:
       - name: Smoke test build
         if: matrix.targetarch == 'x86_64'
         run: ./kwctl-darwin-x86_64 --help
+
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v1
+        id: attestations
+        with:
+          subject-path: kwctl-darwin-${{ matrix.targetarch }}
+
+      - run: |
+          mv \
+            ${{ steps.attestations.outputs.bundle-path }} \
+            kwctl-darwin-${{ matrix.targetarch }}.attestation.sigstore.json
+
+      - name: Upload attestations
+        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4.4.1
+        with:
+          path: kwctl-darwin-${{ matrix.targetarch }}.attestation.sigstore.json
+          name: kwctl-darwin-${{ matrix.targetarch }}.attestation.sigstore.json
 
       - name: Sign kwctl
         run: cosign sign-blob --yes kwctl-darwin-${{ matrix.targetarch }} --output-certificate kwctl-darwin-${{ matrix.targetarch }}.pem --output-signature kwctl-darwin-${{ matrix.targetarch }}.sig
@@ -181,6 +219,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
@@ -206,6 +245,21 @@ jobs:
 
       - name: Smoke test build
         run: .\kwctl-windows-x86_64.exe --help
+
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v1
+        id: attestations
+        with:
+          subject-path: kwctl-windows-${{ matrix.targetarch }}.exe
+
+      - run: |
+          move ${{ steps.attestations.outputs.bundle-path }} kwctl-windows-${{ matrix.targetarch }}.exe.attestation.sigstore.json
+
+      - name: Upload attestations
+        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4.4.1
+        with:
+          path: kwctl-windows-${{ matrix.targetarch }}.exe.attestation.sigstore.json
+          name: kwctl-windows-${{ matrix.targetarch }}.exe.attestation.sigstore.json
 
       - name: Sign kwctl
         run: cosign sign-blob --yes kwctl-windows-x86_64.exe --output-certificate kwctl-windows-x86_64.pem --output-signature kwctl-windows-x86_64.sig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./kwctl-linux-x86_64 --help
 
       - name: Generate attestations
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         id: attestations
         with:
           subject-path: kwctl-linux-${{ matrix.targetarch }}
@@ -139,7 +139,7 @@ jobs:
         run: ./kwctl-darwin-x86_64 --help
 
       - name: Generate attestations
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         id: attestations
         with:
           subject-path: kwctl-darwin-${{ matrix.targetarch }}
@@ -225,7 +225,7 @@ jobs:
         run: .\kwctl-windows-x86_64.exe --help
 
       - name: Generate attestations
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         id: attestations
         with:
           subject-path: kwctl-windows-${{ matrix.targetarch }}.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
     permissions:
       id-token: write
       packages: write
+      actions: read
+      contents: write
+      attestations: write
 
   release:
     name: Create release
@@ -111,6 +114,11 @@ jobs:
               './kwctl-windows-x86_64-sbom/kwctl-windows-x86_64-sbom.spdx',
               './kwctl-windows-x86_64-sbom/kwctl-windows-x86_64-sbom.spdx.cert',
               './kwctl-windows-x86_64-sbom/kwctl-windows-x86_64-sbom.spdx.sig',
+              './kwctl-linux-x86_64.attestation.sigstore.json//kwctl-linux-x86_64.attestation.sigstore.json',
+              './kwctl-linux-aarch64.attestation.sigstore.json/kwctl-linux-aarch64.attestation.sigstore.json',
+              './kwctl-darwin-x86_64.attestation.sigstore.json/kwctl-darwin-x86_64.attestation.sigstore.json',
+              './kwctl-darwin-aarch64.attestation.sigstore.json/kwctl-darwin-aarch64.attestation.sigstore.json',
+              './kwctl-windows-x86_64.exe.attestation.sigstore.json/kwctl-windows-x86_64.exe.attestation.sigstore.json',
               ]
             const {RELEASE_ID} = process.env
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
       packages: write
       actions: read
       contents: write
-      attestations: write
 
   release:
     name: Create release
@@ -114,11 +113,6 @@ jobs:
               './kwctl-windows-x86_64-sbom/kwctl-windows-x86_64-sbom.spdx',
               './kwctl-windows-x86_64-sbom/kwctl-windows-x86_64-sbom.spdx.cert',
               './kwctl-windows-x86_64-sbom/kwctl-windows-x86_64-sbom.spdx.sig',
-              './kwctl-linux-x86_64.attestation.sigstore.json//kwctl-linux-x86_64.attestation.sigstore.json',
-              './kwctl-linux-aarch64.attestation.sigstore.json/kwctl-linux-aarch64.attestation.sigstore.json',
-              './kwctl-darwin-x86_64.attestation.sigstore.json/kwctl-darwin-x86_64.attestation.sigstore.json',
-              './kwctl-darwin-aarch64.attestation.sigstore.json/kwctl-darwin-aarch64.attestation.sigstore.json',
-              './kwctl-windows-x86_64.exe.attestation.sigstore.json/kwctl-windows-x86_64.exe.attestation.sigstore.json',
               ]
             const {RELEASE_ID} = process.env
 

--- a/README.md
+++ b/README.md
@@ -335,14 +335,17 @@ Verified OK
 
 # Software bill of materials & provenance
 
-Kwctl has its software bill of materials (SBOM) and build
-[Provenance](https://slsa.dev/spec/v1.0/provenance) information published every
-release. It follows the [SPDX](https://spdx.dev/) format and
-[SLSA](https://slsa.dev/provenance/v0.2#schema) provenance schema. You can find them together with the signature and certificate used to sign it
-in the [releases assets](https://github.com/kubewarden/kwctl/releases).
+Kwctl has its software bill of materials (SBOM) published every release. They
+follow the [SPDX](https://spdx.dev/) format, you can find them together with
+the signature and certificate used to sign it in the [releases
+assets](https://github.com/kubewarden/kwctl/releases).
 
-The provenance files are also accesible at the GitHub Actions' [provenance](https://github.com/kubewarden/kwctl/attestations) tab.
-For information on their format and how to verify them, see the [GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline).
+The build [Provenance](https://slsa.dev/spec/v1.0/provenance) files are
+following the [SLSA](https://slsa.dev/provenance/v0.2#schema) provenance schema
+and are accesible at the GitHub Actions'
+[provenance](https://github.com/kubewarden/kwctl/attestations) tab. For
+information on their format and how to verify them, see the [GitHub
+documentation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline).
 
 ## Security disclosure
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,17 @@ The output should be:
 Verified OK
 ```
 
+# Software bill of materials & provenance
+
+Kwctl has its software bill of materials (SBOM) and build
+[Provenance](https://slsa.dev/spec/v1.0/provenance) information published every
+release. It follows the [SPDX](https://spdx.dev/) format and
+[SLSA](https://slsa.dev/provenance/v0.2#schema) provenance schema. You can find them together with the signature and certificate used to sign it
+in the [releases assets](https://github.com/kubewarden/kwctl/releases).
+
+The provenance files are also accesible at the GitHub Actions' [provenance](https://github.com/kubewarden/kwctl/attestations) tab.
+For information on their format and how to verify them, see the [GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline).
+
 ## Security disclosure
 
 See [SECURITY.md](https://github.com/kubewarden/community/blob/main/SECURITY.md) on the kubewarden/community repo.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kwctl/issues/933

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Provide provenance for `kwctl` cli utility via GitHub provenance attestation GHA. The intent is to provide a simple approach to provenance. Provenance files will be accesible via https://github.com/kubewarden/kwctl/attestations, as well as shipped in the resulting GH Release, since they are signed via Sigstore.

No care has been taken in refactoring prior SBOMs and their signatures into a checksum file, as each of them are run on their own job from the workflow matrix for now.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested by running it from my fork, with a drop commit to be able to create a tagged release.
See:
https://github.com/viccuad/kwctl/actions/runs/11407858585 (the error is only in triggering the bot PR)
https://github.com/viccuad/kwctl/releases/tag/v1.18.0-viccuad
https://github.com/viccuad/kwctl/attestations


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
