### PR TITLE
ci: Increase timeout for coverage job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ coverage: coverage-unit-tests coverage-e2e-tests
 .PHONY: coverage-unit-tests
 coverage-unit-tests:
 	cargo tarpaulin --verbose --skip-clean --engine=llvm \
-		--all-features --bins --follow-exec \
+		--all-features --implicit-test-threads --bins \
 		--out xml --out html --output-dir coverage/unit-tests
 	
 .PHONY: coverage-e2e-tests


### PR DESCRIPTION

## Description

This is in hopes of reducing tarpaulin time below 15 mins,
so it fits in GHA timeout.

Right now it times out after 15 mins:
https://github.com/kubewarden/kwctl/actions/runs/11442780601

Relates to https://github.com/kubewarden/kwctl/issues/852.
<!-- Please provide the link to the GitHub issue you are addressing -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Tested locally, but cannot know about GHA timeout.
<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
