### PR TITLE
fix: remove tarpaulin e2e test --force-exec flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ coverage-unit-tests:
 .PHONY: coverage-e2e-tests
 coverage-e2e-tests:
 	cargo tarpaulin --verbose --skip-clean --engine=llvm \
-		--all-features --test e2e --follow-exec \
+		--all-features --implicit-test-threads --test e2e \
 		--out xml --out html --output-dir coverage/e2e-tests
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ coverage-unit-tests:
 	
 .PHONY: coverage-e2e-tests
 coverage-e2e-tests:
-	cargo tarpaulin --verbose --skip-clean --engine=llvm \
+	cargo tarpaulin --verbose --skip-clean \
 		--all-features --implicit-test-threads --test e2e \
 		--out xml --out html --output-dir coverage/e2e-tests
 


### PR DESCRIPTION
## Description
Remove `--force-exec` and allow multi-thread execution when running tarpaulin. 

Fixes #952 
