### PR TITLE
test: make tarpaulin tests faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ coverage-unit-tests:
 .PHONY: coverage-e2e-tests
 coverage-e2e-tests:
 	cargo tarpaulin --verbose --skip-clean --engine=llvm \
-		--all-features --test e2e --follow-exec \
+		--all-features --test e2e \
 		--out xml --out html --output-dir coverage/e2e-tests
 
 .PHONY: clean


### PR DESCRIPTION
Make the coverage tests faster by addressing a misconfiguration of tarpaulin.

Fixes https://github.com/kubewarden/kwctl/issues/952
