### PR TITLE
ci: Continue on error for coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
+    continue-on-error: true # https://github.com/xd009642/tarpaulin/issues/1639
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,6 @@ jobs:
           directory: coverage/unit-tests
           flags: unit-tests
           verbose: true
-      - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Generate e2e-tests coverage
         run: make coverage-e2e-tests

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ coverage-unit-tests:
 	
 .PHONY: coverage-e2e-tests
 coverage-e2e-tests:
-	cargo tarpaulin --verbose --skip-clean \
+	cargo tarpaulin --verbose --skip-clean --engine=llvm \
 		--all-features --implicit-test-threads --test e2e \
 		--out xml --out html --output-dir coverage/e2e-tests
 


### PR DESCRIPTION
## Description

Tarpaulin has a memory leak, continue on error for coverage job so releases can go forward.

See: https://github.com/xd009642/tarpaulin/issues/1639

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
