### PR TITLE
automation: switch to cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
-    continue-on-error: true # https://github.com/xd009642/tarpaulin/issues/1639
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
@@ -79,32 +78,25 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: kubewarden/github-actions/tarpaulin-install@d94509d260ee11a92b4f65bc0acd297feec24d7f # v3.3.5
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@d2347103f7c028229cc9c9c440e90b572dd50592 # v2.44.48
+        with:
+          tool: cargo-llvm-cov
 
-      - name: Generate unit-tests coverage
-        run: make coverage-unit-tests
+      - name: Install cosign # this is needed by some of the e2e tests
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+      - name: Generate tests coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
 
       - name: Upload unit-tests coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
         with:
-          name: unit-tests
-          directory: coverage/unit-tests
-          flags: unit-tests
-          verbose: true
-
-      - name: Generate e2e-tests coverage
-        run: make coverage-e2e-tests
-
-      - name: Upload e2e-tests coverage to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-        with:
-          name: e2e-tests
-          directory: coverage/e2e-tests
-          flags: e2e-tests
+          files: lcov.info
+          fail_ci_if_error: true
+          name: unit-tests and e2e-tests
           verbose: true
 
   fmt:

--- a/Makefile
+++ b/Makefile
@@ -19,19 +19,8 @@ e2e-tests:
 	cargo test --test '*'
 	
 .PHONY: coverage
-coverage: coverage-unit-tests coverage-e2e-tests
-	
-.PHONY: coverage-unit-tests
-coverage-unit-tests:
-	cargo tarpaulin --verbose --skip-clean --engine=llvm \
-		--all-features --implicit-test-threads --bins \
-		--out xml --out html --output-dir coverage/unit-tests
-	
-.PHONY: coverage-e2e-tests
-coverage-e2e-tests:
-	cargo tarpaulin --verbose --skip-clean --engine=llvm \
-		--all-features --implicit-test-threads --test e2e \
-		--out xml --out html --output-dir coverage/e2e-tests
+coverage:
+	cargo llvm-cov --html
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Switch to cargo-llvm-cov to collect code coverage results. This is required because tarpaulin is consuming too much memory, leading to our GHA being killed.

See https://github.com/xd009642/tarpaulin/issues/1639 for more details.
