### PR TITLE
chore(deps): update wasmtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ pem = "3"
 pulldown-cmark-mdcat = { version = "2.5.0", default-features = false, features = [
   "regex-fancy",
 ] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.19.2" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.19.3" }
 rustls-pki-types = { version = "1", features = ["alloc"] }
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.12.1", default-features = false }


### PR DESCRIPTION
Use latest version of policy-evaluator. This is required to bump wasmtime dependencies
