### PR TITLE
fix(ci): chore context for patch updates and change schedule.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,12 +29,13 @@
         "*"
       ],
       "automerge": true,
-      "schedule": ["* 0-3 * * *"]
+      "semanticCommits": "enabled",
+      "semanticCommitType": "build"
     }
   ],
   "rebaseWhen": "behind-base-branch",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "semanticCommits": "enabled",
-  "semanticCommitType": "chore"
+  "semanticCommitType": "build"
 }


### PR DESCRIPTION
## Description

Updates the configuration used to bump patch versions of the dependencies to use the "chore" type in the semantic commits and follow the default schedule for renovate bot ("schedule:nonOfficeHours").