### PR TITLE
feat(cli): generate markdown documentation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,18 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - run: shellcheck $(find scripts/ -name '*.sh')
+
+  docs:
+    name: Update documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - run: |
+          make build-docs
+          if ! git diff --quiet cli-docs.md; then
+            echo "Changes detected in cli-docs.md. Please run `make build-docs` and commit the changes."
+            gh run cancel ${{ github.run_id }}
+          fi
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -589,7 +589,7 @@ dependencies = [
  "ipnet",
  "maybe-owned",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -721,6 +721,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
+]
+
+[[package]]
+name = "clap-markdown"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebc67e6266e14f8b31541c2f204724fa2ac7ad5c17d6f5908fbb92a60f42cff"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -1221,6 +1230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,7 +1274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1268,8 +1286,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1279,7 +1309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1476,7 +1506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1638,7 +1668,7 @@ checksum = "5e2e6123af26f0f2c51cc66869137080199406754903cc926a7690401ce09cb4"
 dependencies = [
  "io-lifetimes",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2478,7 +2508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2832,8 +2862,9 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap-markdown",
  "clap_complete",
- "directories",
+ "directories 6.0.0",
  "flate2",
  "humansize",
  "hyper 1.5.2",
@@ -3906,7 +3937,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "cfg-if",
- "directories",
+ "directories 5.0.1",
  "docker_credential",
  "lazy_static",
  "oci-client",
@@ -4292,7 +4323,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4381,6 +4412,17 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -4652,7 +4694,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5460,7 +5502,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -5492,7 +5534,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6910,7 +6952,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7231,7 +7273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.6.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 clap_complete = "4.5"
 clap = { version = "4.5", features = ["cargo", "env"] }
 directories = "6.0.0"
+clap-markdown = "0.1.4"
 flate2 = "1.0.29"
 humansize = "2.1"
 itertools = "0.14.0"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 .PHONY: build
-build:
+build: build-release build-docs
+
+.PHONY: build-release
+build-release:
 	cargo build --release
+
+.PHONY:build-docs
+build-docs:
 	cargo run --release -- docs --output cli-docs.md
 
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build
 build:
 	cargo build --release
+	cargo run --release -- docs --output cli-docs.md
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ There is also:
 
 These are the commands currently supported by kwctl.
 
+If you want a complete list of the available commands, you can read the 
+[cli-docs.md](./cli-docs.md) file.
+
 ### List policies
 
 The list of policies downloaded on the local machine can be

--- a/cli-docs.md
+++ b/cli-docs.md
@@ -1,0 +1,486 @@
+# Command-Line Help for `kwctl`
+
+This document contains the help content for the `kwctl` command-line program.
+
+**Command Overview:**
+
+* [`kwctl`↴](#kwctl)
+* [`kwctl annotate`↴](#kwctl-annotate)
+* [`kwctl bench`↴](#kwctl-bench)
+* [`kwctl completions`↴](#kwctl-completions)
+* [`kwctl digest`↴](#kwctl-digest)
+* [`kwctl docs`↴](#kwctl-docs)
+* [`kwctl info`↴](#kwctl-info)
+* [`kwctl inspect`↴](#kwctl-inspect)
+* [`kwctl load`↴](#kwctl-load)
+* [`kwctl policies`↴](#kwctl-policies)
+* [`kwctl pull`↴](#kwctl-pull)
+* [`kwctl push`↴](#kwctl-push)
+* [`kwctl rm`↴](#kwctl-rm)
+* [`kwctl run`↴](#kwctl-run)
+* [`kwctl save`↴](#kwctl-save)
+* [`kwctl scaffold`↴](#kwctl-scaffold)
+* [`kwctl scaffold admission-request`↴](#kwctl-scaffold-admission-request)
+* [`kwctl scaffold artifacthub`↴](#kwctl-scaffold-artifacthub)
+* [`kwctl scaffold manifest`↴](#kwctl-scaffold-manifest)
+* [`kwctl scaffold vap`↴](#kwctl-scaffold-vap)
+* [`kwctl scaffold verification-config`↴](#kwctl-scaffold-verification-config)
+* [`kwctl verify`↴](#kwctl-verify)
+
+## `kwctl`
+
+Tool to manage Kubewarden policies
+
+**Usage:** `kwctl [OPTIONS] <COMMAND>`
+
+###### **Subcommands:**
+
+* `annotate` — Add Kubewarden metadata to a WebAssembly module
+* `bench` — Benchmarks a Kubewarden policy
+* `completions` — Generate shell completions
+* `digest` — Fetch digest from the OCI manifest of a policy
+* `docs` — Generates the markdown documentation for kwctl commands
+* `info` — Display system information
+* `inspect` — Inspect Kubewarden policy
+* `load` — load policies from a tar.gz file
+* `policies` — Lists all downloaded policies
+* `pull` — Pulls a Kubewarden policy from a given URI
+* `push` — Pushes a Kubewarden policy to an OCI registry
+* `rm` — Removes a Kubewarden policy from the store
+* `run` — Runs a Kubewarden policy from a given URI
+* `save` — save policies to a tar.gz file
+* `scaffold` — Scaffold a Kubernetes resource or configuration file
+* `verify` — Verify a Kubewarden policy from a given URI using Sigstore
+
+###### **Options:**
+
+* `-v`, `--verbose <VERBOSE>` — Increase verbosity
+* `--no-color <NO-COLOR>` — Disable colorful output
+
+
+
+## `kwctl annotate`
+
+Add Kubewarden metadata to a WebAssembly module
+
+**Usage:** `kwctl annotate [OPTIONS] --metadata-path <PATH> --output-path <PATH> <wasm-path>`
+
+###### **Arguments:**
+
+* `<WASM-PATH>` — Path to WebAssembly module to be annotated
+
+###### **Options:**
+
+* `-m`, `--metadata-path <PATH>` — File containing the metadata
+* `-o`, `--output-path <PATH>` — Output file
+* `-u`, `--usage-path <PATH>` — File containing the usage information of the policy
+
+
+
+## `kwctl bench`
+
+Benchmarks a Kubewarden policy
+
+**Usage:** `kwctl bench [OPTIONS] --request-path <PATH> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--dump-results-to-disk <DUMP_RESULTS_TO_DISK>` — Puts results in target/tiny-bench/label/.. if target can be found. used for comparing previous runs
+* `-e`, `--execution-mode <MODE>` — The runtime to use to execute this policy
+
+  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
+
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--measurement-time <SECONDS>` — How long the bench ‘should’ run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed
+* `--num-resamples <NUM>` — How many resamples should be done
+* `--num-samples <NUM>` — How many resamples should be done. Recommended at least 50, above 100 doesn’t seem to yield a significantly different result
+* `--raw <RAW>` — Validate a raw request
+
+  Default value: `false`
+* `--record-host-capabilities-interactions <FILE>` — Record all the policy <-> host capabilities
+   communications to the given file.
+   Useful to be combined later with '--replay-host-capabilities-interactions' flag
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--replay-host-capabilities-interactions <FILE>` — During policy <-> host capabilities exchanges
+   the host replays back the answers found inside of the provided file.
+   This is useful to test policies in a reproducible way, given no external
+   interactions with OCI registries, DNS, Kubernetes are performed.
+* `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+* `--warm-up-time <SECONDS>` — How long the bench should warm up
+
+
+
+## `kwctl completions`
+
+Generate shell completions
+
+**Usage:** `kwctl completions --shell <VALUE>`
+
+###### **Options:**
+
+* `-s`, `--shell <VALUE>` — Shell type
+
+  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+
+
+
+
+## `kwctl digest`
+
+Fetch digest from the OCI manifest of a policy
+
+**Usage:** `kwctl digest [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl docs`
+
+Generates the markdown documentation for kwctl commands
+
+**Usage:** `kwctl docs --output <FILE>`
+
+###### **Options:**
+
+* `-o`, `--output <FILE>` — path where the documentation file will be stored
+
+
+
+## `kwctl info`
+
+Display system information
+
+**Usage:** `kwctl info`
+
+
+
+## `kwctl inspect`
+
+Inspect Kubewarden policy
+
+**Usage:** `kwctl inspect [OPTIONS] <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-o`, `--output <FORMAT>` — Output format
+
+  Possible values: `yaml`
+
+* `--show-signatures <SHOW-SIGNATURES>` — Show sigstore signatures
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl load`
+
+load policies from a tar.gz file
+
+**Usage:** `kwctl load --input <input>`
+
+###### **Options:**
+
+* `--input <INPUT>` — load policies from tarball
+
+
+
+## `kwctl policies`
+
+Lists all downloaded policies
+
+**Usage:** `kwctl policies`
+
+
+
+## `kwctl pull`
+
+Pulls a Kubewarden policy from a given URI
+
+**Usage:** `kwctl pull [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI. Supported schemes: registry://, https://, file://
+
+###### **Options:**
+
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <DOCKER_CONFIG>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `-o`, `--output-path <PATH>` — Output file. If not provided will be downloaded to the Kubewarden store
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key. Can be repeated multiple times
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl push`
+
+Pushes a Kubewarden policy to an OCI registry
+
+**Usage:** `kwctl push [OPTIONS] <policy> <uri>`
+
+###### **Arguments:**
+
+* `<POLICY>` — Policy to push. Can be the path to a local file, a policy URI or the SHA prefix of a policy in the store.
+* `<URI>` — Policy URI. Supported schemes: registry://
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-f`, `--force <FORCE>` — Push also a policy that is not annotated
+* `-o`, `--output <PATH>` — Output format
+
+  Default value: `text`
+
+  Possible values: `text`, `json`
+
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl rm`
+
+Removes a Kubewarden policy from the store
+
+**Usage:** `kwctl rm <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix
+
+
+
+## `kwctl run`
+
+Runs a Kubewarden policy from a given URI
+
+**Usage:** `kwctl run [OPTIONS] --request-path <PATH> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-e`, `--execution-mode <MODE>` — The runtime to use to execute this policy
+
+  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
+
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--raw <RAW>` — Validate a raw request
+
+  Default value: `false`
+* `--record-host-capabilities-interactions <FILE>` — Record all the policy <-> host capabilities
+   communications to the given file.
+   Useful to be combined later with '--replay-host-capabilities-interactions' flag
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--replay-host-capabilities-interactions <FILE>` — During policy <-> host capabilities exchanges
+   the host replays back the answers found inside of the provided file.
+   This is useful to test policies in a reproducible way, given no external
+   interactions with OCI registries, DNS, Kubernetes are performed.
+* `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl save`
+
+save policies to a tar.gz file
+
+**Usage:** `kwctl save --output <FILE> <policies>...`
+
+###### **Arguments:**
+
+* `<POLICIES>` — list of policies to save
+
+###### **Options:**
+
+* `-o`, `--output <FILE>` — path where the file will be stored
+
+
+
+## `kwctl scaffold`
+
+Scaffold a Kubernetes resource or configuration file
+
+**Usage:** `kwctl scaffold <COMMAND>`
+
+###### **Subcommands:**
+
+* `admission-request` — Scaffold an AdmissionRequest object
+* `artifacthub` — Output an artifacthub-pkg.yml file from a metadata.yml file
+* `manifest` — Output a Kubernetes resource manifest
+* `vap` — Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`
+* `verification-config` — Output a default Sigstore verification configuration file
+
+
+
+## `kwctl scaffold admission-request`
+
+Scaffold an AdmissionRequest object
+
+**Usage:** `kwctl scaffold admission-request [OPTIONS] --operation <TYPE>`
+
+###### **Options:**
+
+* `--object <PATH>` — The file containing the new object being admitted
+* `--old-object <PATH>` — The file containing the existing object
+* `-o`, `--operation <TYPE>` — Kubewarden Custom Resource type
+
+  Possible values: `CREATE`
+
+
+
+
+## `kwctl scaffold artifacthub`
+
+Output an artifacthub-pkg.yml file from a metadata.yml file
+
+**Usage:** `kwctl scaffold artifacthub [OPTIONS] --metadata-path <PATH> --version <VALUE>`
+
+###### **Options:**
+
+* `-m`, `--metadata-path <PATH>` — File containing the metadata of the policy
+* `-o`, `--output <FILE>` — Path where the artifact-pkg.yml file will be stored
+* `-q`, `--questions-path <PATH>` — File containing the questions-ui content of the policy
+* `-v`, `--version <VALUE>` — Semver version of the policy
+
+
+
+## `kwctl scaffold manifest`
+
+Output a Kubernetes resource manifest
+
+**Usage:** `kwctl scaffold manifest [OPTIONS] --type <VALUE> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Uses the policy metadata to define which Kubernetes resources can be accessed by the policy. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <DOCKER_CONFIG>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key. Can be repeated multiple times
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `--title <VALUE>` — Policy title
+* `-t`, `--type <VALUE>` — Kubewarden Custom Resource type
+
+  Possible values: `ClusterAdmissionPolicy`, `AdmissionPolicy`
+
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl scaffold vap`
+
+Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`
+
+**Usage:** `kwctl scaffold vap [OPTIONS] --binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml> --policy <VALIDATING-ADMISSION-POLICY.yaml>`
+
+###### **Options:**
+
+* `-b`, `--binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml>` — The file containining the ValidatingAdmissionPolicyBinding definition
+* `--cel-policy <URI>` — The CEL policy module to use
+
+  Default value: `ghcr.io/kubewarden/policies/cel-policy:latest`
+* `-p`, `--policy <VALIDATING-ADMISSION-POLICY.yaml>` — The file containining the ValidatingAdmissionPolicy definition
+
+
+
+## `kwctl scaffold verification-config`
+
+Output a default Sigstore verification configuration file
+
+**Usage:** `kwctl scaffold verification-config`
+
+
+
+## `kwctl verify`
+
+Verify a Kubewarden policy from a given URI using Sigstore
+
+**Usage:** `kwctl verify [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI. Supported schemes: registry://
+
+###### **Options:**
+
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -623,6 +623,19 @@ fn subcommand_save() -> Command {
         )
 }
 
+fn subcommand_docs() -> Command {
+    Command::new("docs")
+        .about("Generates the markdown documentation for kwctl commands")
+        .arg(
+            Arg::new("output")
+                .long("output")
+                .short('o')
+                .required(true)
+                .value_name("FILE")
+                .help("path where the documentation file will be stored"),
+        )
+}
+
 pub fn build_cli() -> Command {
     let mut subcommands = vec![
         Command::new("policies").about("Lists all downloaded policies"),
@@ -670,6 +683,7 @@ pub fn build_cli() -> Command {
         subcommand_digest(),
         subcommand_bench(),
         subcommand_save(),
+        subcommand_docs(),
     ];
     subcommands.sort_by(|a, b| a.get_name().cmp(b.get_name()));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ use policy_evaluator::{
         PullDestination,
     },
 };
+use std::io::prelude::*;
 
 use crate::utils::new_policy_execution_mode_from_str;
 
@@ -407,6 +408,17 @@ async fn main() -> Result<()> {
             if let Some(matches) = matches.subcommand_matches("load") {
                 let input = matches.get_one::<String>("input").unwrap();
                 load(input)?;
+            }
+            Ok(())
+        }
+        Some("docs") => {
+            if let Some(matches) = matches.subcommand_matches("docs") {
+                let output = matches.get_one::<String>("output").unwrap();
+                let mut file = std::fs::File::create(output)
+                    .map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
+                let docs_content = clap_markdown::help_markdown_command(&cli::build_cli());
+                file.write_all(docs_content.as_bytes())
+                    .map_err(|e| anyhow!("cannot write to file {}: {}", output, e))?;
             }
             Ok(())
         }


### PR DESCRIPTION
## Description

Adds a new kwctl subcommand to allow users to generate a markdown documentation with all the commands available in kwctl.

Part of #851 

## Test

```shell
make && ./target/release/kwctl docs --output cli-docs.md
```
