### PR TITLE
chore(ci): use common renovate bot configuration.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,40 +1,5 @@
 {
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigests",
-    "schedule:nonOfficeHours"
-  ],
-  "labels": [
-    "area/dependencies"
-  ],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 4am on monday"],
-    "automerge": true
-  },
-  "major": {
-    "automerge": false
-  },
-  "minor": {
-    "automerge": false
-  },
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "groupName": "all patch level dependencies",
-      "groupSlug": "all-patch",
-      "matchPackageNames": [
-        "*"
-      ],
-      "automerge": true,
-      "schedule": ["* 0-3 * * *"]
-    }
-  ],
-  "rebaseWhen": "behind-base-branch",
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
-  "semanticCommits": "enabled",
-  "semanticCommitType": "chore"
+    "github>kubewarden/github-actions//renovate-config/default"
+  ]
 }


### PR DESCRIPTION
## Description

Updates the renovate bot configuration to uses the default configuration used by all the major Kubewarden components.

