### PR TITLE
fix(docs): remove invalid char in docs website.

### DIFF
--- a/cli-docs.md
+++ b/cli-docs.md
@@ -108,11 +108,11 @@ Benchmarks a Kubewarden policy
 * `--raw <RAW>` — Validate a raw request
 
   Default value: `false`
-* `--record-host-capabilities-interactions <FILE>` — Record all the policy <-> host capabilities
+* `--record-host-capabilities-interactions <FILE>` — Record all the policy and host capabilities
    communications to the given file.
    Useful to be combined later with '--replay-host-capabilities-interactions' flag
 * `--rekor-public-key-path <PATH>` — Path to the Rekor public key
-* `--replay-host-capabilities-interactions <FILE>` — During policy <-> host capabilities exchanges
+* `--replay-host-capabilities-interactions <FILE>` — During policy and host capabilities exchanges
    the host replays back the answers found inside of the provided file.
    This is useful to test policies in a reproducible way, given no external
    interactions with OCI registries, DNS, Kubernetes are performed.
@@ -312,11 +312,11 @@ Runs a Kubewarden policy from a given URI
 * `--raw <RAW>` — Validate a raw request
 
   Default value: `false`
-* `--record-host-capabilities-interactions <FILE>` — Record all the policy <-> host capabilities
+* `--record-host-capabilities-interactions <FILE>` — Record all the policy and host capabilities
    communications to the given file.
    Useful to be combined later with '--replay-host-capabilities-interactions' flag
 * `--rekor-public-key-path <PATH>` — Path to the Rekor public key
-* `--replay-host-capabilities-interactions <FILE>` — During policy <-> host capabilities exchanges
+* `--replay-host-capabilities-interactions <FILE>` — During policy and host capabilities exchanges
    the host replays back the answers found inside of the provided file.
    This is useful to test policies in a reproducible way, given no external
    interactions with OCI registries, DNS, Kubernetes are performed.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -306,13 +306,13 @@ fn run_args() -> Vec<Arg> {
         Arg::new("record-host-capabilities-interactions")
             .long("record-host-capabilities-interactions")
             .value_name("FILE")
-            .long_help(r#"Record all the policy <-> host capabilities
+            .long_help(r#"Record all the policy and host capabilities
 communications to the given file.
 Useful to be combined later with '--replay-host-capabilities-interactions' flag"#),
         Arg::new("replay-host-capabilities-interactions")
             .long("replay-host-capabilities-interactions")
             .value_name("FILE")
-            .long_help(r#"During policy <-> host capabilities exchanges
+            .long_help(r#"During policy and host capabilities exchanges
 the host replays back the answers found inside of the provided file.
 This is useful to test policies in a reproducible way, given no external
 interactions with OCI registries, DNS, Kubernetes are performed."#),


### PR DESCRIPTION
## Description

It's necessary to add the cli-docs.md file content in the Kubewarden docs website. However, some CLI flag has invalid chart that prevent the usage of the file. This commit replace these chars and use a word instead. Therefore, the file can be rendered by the docs website.


Part of  #851 
