### PR TITLE
feat: OCI annotations

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,5 @@
+[formatting]
+align_entries  = true
+reorder_arrays = true
+reorder_keys   = true
+sort_keys      = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.19.11#e9577caf16b5850ac6f70bbd8ac89df474a4c7eb"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.20.0#77e206cfa3609e7d7da78d8ee3945c9e9b2d8cee"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3888,8 +3888,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.19.11"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.19.11#e9577caf16b5850ac6f70bbd8ac89df474a4c7eb"
+version = "0.20.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.20.0#77e206cfa3609e7d7da78d8ee3945c9e9b2d8cee"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3929,14 +3929,15 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.9.0"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.9.0#ffc16c3f0c4400533c2130d44bdc46a3c7ede747"
+version = "0.10.0"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.10.0#262b50ad0dd237118c48f232e81f5748b301d719"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "cfg-if",
  "directories",
  "docker_credential",
+ "futures",
  "lazy_static",
  "oci-client",
  "path-slash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "kwctl"
+authors     = ["Kubewarden Developers <kubewarden@suse.de>"]
 description = "Tool to manage Kubewarden policies"
-version = "1.21.1"
-authors = ["Kubewarden Developers <kubewarden@suse.de>"]
-edition = "2021"
+edition     = "2021"
+name        = "kwctl"
+version     = "1.21.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0"
-clap_complete = "4.5"
 clap = { version = "4.5", features = ["cargo", "env"] }
-directories = "6.0.0"
 clap-markdown = "0.1.4"
+clap_complete = "4.5"
+directories = "6.0.0"
 flate2 = "1.0.29"
 humansize = "2.1"
 itertools = "0.14.0"
@@ -21,14 +21,15 @@ k8s-openapi = { version = "0.24.0", default-features = false, features = [
 ] }
 lazy_static = "1.4.0"
 pem = "3"
-pulldown-cmark-mdcat = { version = "2.7.1", default-features = false }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.19.11" }
-rustls-pki-types = { version = "1", features = ["alloc"] }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.20.0" }
 prettytable-rs = "^0.10"
 pulldown-cmark = { version = "0.12.1", default-features = false }
+pulldown-cmark-mdcat = { version = "2.7.1", default-features = false }
 regex = "1"
-serde_json = "1.0"
+rustls-pki-types = { version = "1", features = ["alloc"] }
+semver = { version = "1.0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 serde_yaml = "0.9.34"
 syntect = { version = "5.2", default-features = false, features = [
   "default-syntaxes",
@@ -36,6 +37,7 @@ syntect = { version = "5.2", default-features = false, features = [
 ] }
 tar = "0.4.40"
 thiserror = "2.0"
+time = "0.3.36"
 tiny-bench = "0.4"
 tokio = { version = "^1.42.0", features = ["full"] }
 tracing = "0.1"
@@ -43,8 +45,6 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 url = "2.5.0"
 walrus = "0.23.0"
 wasmparser = "0.225"
-time = "0.3.36"
-semver = { version = "1.0.22", features = ["serde"] }
 
 # This is required to have reqwest built using the `rustls-tls-native-roots`
 # feature across all the transitive dependencies of kwctl
@@ -55,10 +55,10 @@ reqwest = { version = "0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
-hyper = { version = "1.5.0" }
-predicates = "3.1"
-rstest = "0.24.0"
-tempfile = "3.15"
+assert_cmd     = "2.0.14"
+hyper          = { version = "1.5.0" }
+predicates     = "3.1"
+rstest         = "0.24.0"
+tempfile       = "3.15"
 testcontainers = { version = "0.23", features = ["blocking"] }
-tower-test = "0.4"
+tower-test     = "0.4"

--- a/cli-docs.md
+++ b/cli-docs.md
@@ -254,6 +254,11 @@ Pushes a Kubewarden policy to an OCI registry
 
 **Usage:** `kwctl push [OPTIONS] <policy> <uri>`
 
+The annotations found inside of policy's metadata are going to be part of the OCI manifest.
+The multi-line annotations are skipped because they are not compatible with the OCI specification.
+The 'io.kubewarden.policy.source' annotation is propaged as 'org.opencontainers.image.source' to allow tools like
+renovatebot to detect policy updates.
+
 ###### **Arguments:**
 
 * `<POLICY>` — Policy to push. Can be the path to a local file, a policy URI or the SHA prefix of a policy in the store.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -208,6 +208,12 @@ fn subcommand_push() -> Command {
 
     Command::new("push")
         .about("Pushes a Kubewarden policy to an OCI registry")
+        .after_long_help(
+            r#"The annotations found inside of policy's metadata are going to be part of the OCI manifest.
+The multi-line annotations are skipped because they are not compatible with the OCI specification.
+The 'io.kubewarden.policy.source' annotation is propaged as 'org.opencontainers.image.source' to allow tools like
+renovatebot to detect policy updates."#,
+        )
         .args(args)
 }
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,7 +1,15 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
 use anyhow::{anyhow, Result};
-use policy_evaluator::policy_fetcher::{registry::Registry, sources::Sources};
-use policy_evaluator::policy_metadata::Metadata;
-use std::{fs, path::PathBuf};
+use policy_evaluator::{
+    constants::KUBEWARDEN_ANNOTATION_POLICY_SOURCE,
+    policy_fetcher::{
+        oci_client::annotations::ORG_OPENCONTAINERS_IMAGE_SOURCE, registry::Registry,
+        sources::Sources,
+    },
+    policy_metadata::Metadata,
+};
+use tracing::warn;
 
 use crate::backend::BackendDetector;
 
@@ -11,25 +19,26 @@ pub(crate) async fn push(
     sources: Option<&Sources>,
     force: bool,
 ) -> Result<String> {
-    match Metadata::from_path(&wasm_path)? {
-        Some(_) => {}
-        None => {
-            if force {
-                let backend_detector = BackendDetector::default();
-                if can_be_force_pushed_without_metadata(backend_detector, wasm_path.clone())? {
-                    eprintln!("Warning: pushing a non-annotated policy!");
-                } else {
-                    return Err(anyhow!("Rego policies cannot be pushed without metadata"));
-                }
+    let metadata = Metadata::from_path(&wasm_path)?;
+
+    if metadata.is_none() {
+        if force {
+            let backend_detector = BackendDetector::default();
+            if can_be_force_pushed_without_metadata(backend_detector, wasm_path.clone())? {
+                eprintln!("Warning: pushing a non-annotated policy!");
             } else {
-                return Err(anyhow!("Cannot push a policy that is not annotated. Use `annotate` command or `push --force`"));
+                return Err(anyhow!("Rego policies cannot be pushed without metadata"));
             }
+        } else {
+            return Err(anyhow!("Cannot push a policy that is not annotated. Use `annotate` command or `push --force`"));
         }
-    };
+    }
+
+    let annotations = metadata.and_then(|meta| meta.annotations.map(build_oci_annotations));
 
     let policy = fs::read(&wasm_path).map_err(|e| anyhow!("Cannot open policy file: {:?}", e))?;
     Registry::new()
-        .push(&policy, uri, sources)
+        .push(&policy, uri, sources, annotations)
         .await
         .map_err(anyhow::Error::new)
 }
@@ -43,4 +52,110 @@ fn can_be_force_pushed_without_metadata(
         .map_err(|e| anyhow!("Cannot understand if the policy is based on Rego: {:?}", e))?;
 
     Ok(!is_rego)
+}
+
+/// Augment the annotations with the `org.opencontainers.image.source`
+/// annotation, if the `io.kubewarden.policy.source` annotation is present.
+fn build_oci_annotations(annotations: BTreeMap<String, String>) -> BTreeMap<String, String> {
+    // filter all the multi-line annotations, they are not supported by the OCI spec
+    let mut annotations: BTreeMap<String, String> = annotations
+        .iter()
+        .filter(|(k, v)| {
+            let filter = v.lines().count() <= 1;
+            if filter {
+                warn!(
+                    annotation = k,
+                    "annotation is a multi-line string, it will be removed from the OCI manifest",
+                );
+            }
+            filter
+        })
+        .map(|(k, v)| (k.to_owned(), v.to_owned()))
+        .collect();
+
+    if let Some(source) = annotations.get(KUBEWARDEN_ANNOTATION_POLICY_SOURCE) {
+        if !annotations.contains_key(ORG_OPENCONTAINERS_IMAGE_SOURCE) {
+            annotations.insert(
+                ORG_OPENCONTAINERS_IMAGE_SOURCE.to_string(),
+                source.to_owned(),
+            );
+        }
+    }
+
+    annotations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use policy_evaluator::constants::{
+        KUBEWARDEN_ANNOTATION_POLICY_URL, KUBEWARDEN_ANNOTATION_POLICY_USAGE,
+    };
+
+    #[test]
+    fn test_build_oci_annotations_propagate_policy_source() {
+        let policy_source = "example.com";
+        let policy_url = "http://example.com";
+
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            KUBEWARDEN_ANNOTATION_POLICY_SOURCE.to_string(),
+            policy_source.to_string(),
+        );
+        annotations.insert(
+            KUBEWARDEN_ANNOTATION_POLICY_URL.to_string(),
+            policy_url.to_string(),
+        );
+        annotations.insert(
+            KUBEWARDEN_ANNOTATION_POLICY_USAGE.to_string(),
+            "this is a multi-line\nstring".to_string(),
+        );
+
+        let actual = build_oci_annotations(annotations);
+
+        assert!(!actual.contains_key(KUBEWARDEN_ANNOTATION_POLICY_USAGE));
+        assert_eq!(
+            actual.get(ORG_OPENCONTAINERS_IMAGE_SOURCE).unwrap(),
+            policy_source
+        );
+        assert_eq!(
+            actual.get(KUBEWARDEN_ANNOTATION_POLICY_URL).unwrap(),
+            policy_url,
+        );
+        assert_eq!(
+            actual.get(KUBEWARDEN_ANNOTATION_POLICY_SOURCE).unwrap(),
+            policy_source
+        );
+    }
+
+    #[test]
+    fn test_build_oci_annotations_do_not_overwrite_oci_source_if_already_set() {
+        let policy_source = "example.com";
+        let oci_source = "oci.org";
+
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            KUBEWARDEN_ANNOTATION_POLICY_SOURCE.to_string(),
+            policy_source.to_string(),
+        );
+        annotations.insert(
+            KUBEWARDEN_ANNOTATION_POLICY_USAGE.to_string(),
+            "this is a multi-line\nstring".to_string(),
+        );
+        annotations.insert(
+            ORG_OPENCONTAINERS_IMAGE_SOURCE.to_string(),
+            oci_source.to_string(),
+        );
+
+        let actual = build_oci_annotations(annotations);
+        assert!(!actual.contains_key(KUBEWARDEN_ANNOTATION_POLICY_USAGE));
+        assert_eq!(
+            actual.get(ORG_OPENCONTAINERS_IMAGE_SOURCE).unwrap(),
+            oci_source
+        );
+        assert_eq!(
+            actual.get(KUBEWARDEN_ANNOTATION_POLICY_SOURCE).unwrap(),
+            policy_source
+        );
+    }
 }

--- a/src/scaffold/manifest.rs
+++ b/src/scaffold/manifest.rs
@@ -1,3 +1,9 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::TryFrom,
+    str::FromStr,
+};
+
 use anyhow::{anyhow, Result};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use policy_evaluator::{
@@ -7,11 +13,6 @@ use policy_evaluator::{
     },
     policy_metadata::Metadata,
     validator::Validate,
-};
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
-    convert::TryFrom,
-    str::FromStr,
 };
 use tracing::warn;
 
@@ -159,7 +160,7 @@ fn get_policy_title_from_cli_or_metadata(
         metadata
             .annotations
             .as_ref()
-            .unwrap_or(&HashMap::new())
+            .unwrap_or(&BTreeMap::new())
             .get(KUBEWARDEN_ANNOTATION_POLICY_TITLE)
             .map(|s| s.to_string())
     })
@@ -223,7 +224,7 @@ mod tests {
         Metadata {
             protocol_version: None,
             rules: vec![],
-            annotations: Some(HashMap::from([(
+            annotations: Some(BTreeMap::from([(
                 KUBEWARDEN_ANNOTATION_POLICY_TITLE.to_string(),
                 title.to_string(),
             )])),
@@ -240,7 +241,7 @@ mod tests {
         Metadata {
             protocol_version: None,
             rules: vec![],
-            annotations: Some(HashMap::from([
+            annotations: Some(BTreeMap::from([
                 (
                     KUBEWARDEN_ANNOTATION_POLICY_TITLE.to_string(),
                     String::from("test"),


### PR DESCRIPTION
When pushing a policy to an OCI registry, add all the Kubewarden annotations found inside of policy's metadata to the resulting OCI manifest.

The KW annotations that are multi-line will be skipped, since they are not compliant with the OCI spec.

Moreover, the `io.kubewarden.policy.source` is propaged as `org.opencontainers.image.source` to allow tools like renovatebot to handle policy updates.

Fixes https://github.com/kubewarden/kwctl/issues/1044

Finally, I've added a `taplo.toml` configuration to the project to keep our `Cargo.toml` file nice and tidy.
