### PR TITLE
feat!: change how artifacthub scaffold works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,14 +307,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
 dependencies = [
- "getrandom 0.2.15",
- "instant",
- "rand",
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.21.0#83a3239f0373e736567e2a74b1a2f0a4533431aa"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.22.0#298db503f28c9f557dd94e832dccc22a44a9f388"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -505,7 +505,7 @@ dependencies = [
  "gtmpl",
  "gtmpl_value",
  "itertools 0.14.0",
- "json-patch 4.0.0",
+ "json-patch",
  "lazy_static",
  "regex",
  "semver",
@@ -2073,6 +2073,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,15 +2647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-extras"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,23 +2784,11 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
-dependencies = [
- "jsonptr 0.6.3",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "json-patch"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
 dependencies = [
- "jsonptr 0.7.1",
+ "jsonptr",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2833,16 +2824,6 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "jsonptr"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2894,9 +2875,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32053dc495efad4d188c7b33cc7c02ef4a6e43038115348348876efd39a53cba"
+checksum = "9a4eb20010536b48abe97fec37d23d43069bcbe9686adcf9932202327bc5ca6e"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2906,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d34ad38cdfbd1fa87195d42569f57bb1dda6ba5f260ee32fef9570b7937a0c9"
+checksum = "7fc2ed952042df20d15ac2fe9614d0ec14b6118eab89633985d4b36e688dccf1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2929,7 +2910,6 @@ dependencies = [
  "kube-core",
  "pem",
  "rustls",
- "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -2944,14 +2924,14 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97aa830b288a178a90e784d1b0f1539f2d200d2188c7b4a3146d9dc983d596f3"
+checksum = "ff0d0793db58e70ca6d689489183816cb3aa481673e7433dc618cf7e8007c675"
 dependencies = [
  "chrono",
  "form_urlencoded",
  "http",
- "json-patch 3.0.1",
+ "json-patch",
  "k8s-openapi",
  "serde",
  "serde-value",
@@ -2961,21 +2941,20 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a41af186a0fe80c71a13a13994abdc3ebff80859ca6a4b8a6079948328c135b"
+checksum = "88f34cfab9b4bd8633062e0e85edb81df23cb09f159f2e31c60b069ae826ffdc"
 dependencies = [
  "ahash 0.8.11",
  "async-broadcast",
  "async-stream",
  "async-trait",
- "backoff",
+ "backon",
  "educe",
  "futures",
  "hashbrown 0.15.2",
  "hostname",
- "json-patch 3.0.1",
- "jsonptr 0.6.3",
+ "json-patch",
  "k8s-openapi",
  "kube-client",
  "parking_lot",
@@ -3186,7 +3165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4079,8 +4058,8 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.21.0"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.21.0#83a3239f0373e736567e2a74b1a2f0a4533431aa"
+version = "0.22.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.22.0#298db503f28c9f557dd94e832dccc22a44a9f388"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4091,7 +4070,7 @@ dependencies = [
  "email_address",
  "futures",
  "itertools 0.14.0",
- "json-patch 4.0.0",
+ "json-patch",
  "k8s-openapi",
  "kube",
  "kubewarden-policy-sdk",
@@ -4112,7 +4091,7 @@ dependencies = [
  "validator",
  "wapc",
  "wasi-common",
- "wasmparser 0.226.0",
+ "wasmparser 0.227.1",
  "wasmtime",
  "wasmtime-provider",
  "wasmtime-wasi",
@@ -6531,19 +6510,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.226.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc28600dcb2ba68d7e5f1c3ba4195c2bddc918c0243fd702d0b6dbd05689b681"
-dependencies = [
- "bitflags 2.8.0",
- "hashbrown 0.15.2",
- "indexmap 2.7.1",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
@@ -7053,7 +7019,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ k8s-openapi = { version = "0.24.0", default-features = false, features = [
 ] }
 lazy_static = "1.4.0"
 pem = "3"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.21.0" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.22.0" }
 prettytable-rs = "^0.10"
 regex = "1"
 rustls-pki-types = { version = "1", features = ["alloc"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -423,19 +423,12 @@ fn subcommand_scaffold() -> Command {
             .value_name("PATH")
             .help("File containing the metadata of the policy"),
         Arg::new("version")
-            .required(true)
+            .required(false)
             .long("version")
             .short('v')
             .number_of_values(1)
             .value_name("VALUE")
             .help("Semver version of the policy"),
-        Arg::new("gh-release-tag")
-            .required(false)
-            .long("gh-release-tag")
-            .short('t')
-            .number_of_values(1)
-            .value_name("VALUE")
-            .help("Specifies the GitHub release tag of the policy. If set, this tag will be used for generating GitHub release links instead of the version."),
         Arg::new("questions-path")
             .long("questions-path")
             .short('q')

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,19 +323,13 @@ async fn main() -> Result<()> {
                         .get_one::<String>("metadata-path")
                         .map(|output| PathBuf::from_str(output).unwrap())
                         .unwrap();
-                    let version = artifacthub_matches.get_one::<String>("version").unwrap();
-                    let gh_release_tag = artifacthub_matches
-                        .get_one::<String>("gh-release-tag")
-                        .cloned();
+                    if artifacthub_matches.get_one::<String>("version").is_some() {
+                        tracing::warn!("The 'version' flag is deprecated and will be removed in a future release. The value of the `io.kubewarden.policy.version` field in the policy metadata file is used instead.");
+                    }
                     let questions_file = artifacthub_matches
                         .get_one::<String>("questions-path")
                         .map(|output| PathBuf::from_str(output).unwrap());
-                    let content = scaffold::artifacthub(
-                        metadata_file,
-                        version,
-                        gh_release_tag.as_deref(),
-                        questions_file,
-                    )?;
+                    let content = scaffold::artifacthub(metadata_file, questions_file)?;
                     if let Some(output) = artifacthub_matches.get_one::<String>("output") {
                         let output_path = PathBuf::from_str(output)?;
                         fs::write(output_path, content)?;

--- a/src/scaffold/artifacthub.rs
+++ b/src/scaffold/artifacthub.rs
@@ -8,8 +8,6 @@ use time::OffsetDateTime;
 
 pub(crate) fn artifacthub(
     metadata_path: PathBuf,
-    version: &str,
-    gh_release_tag: Option<&str>,
     questions_path: Option<PathBuf>,
 ) -> Result<String> {
     let comment_header = r#"# Kubewarden Artifacthub Package config
@@ -29,13 +27,8 @@ pub(crate) fn artifacthub(
         })
         .transpose()?;
 
-    let kubewarden_artifacthub_pkg = ArtifactHubPkg::from_metadata(
-        &metadata,
-        version,
-        gh_release_tag,
-        OffsetDateTime::now_utc(),
-        questions.as_deref(),
-    )?;
+    let kubewarden_artifacthub_pkg =
+        ArtifactHubPkg::from_metadata(&metadata, OffsetDateTime::now_utc(), questions.as_deref())?;
 
     Ok(format!(
         "{}\n{}",


### PR DESCRIPTION
Scaffolding the artifacthub-pkg file relies on annotations put inside of the `metadata.yml` file.

Because of that, some flags of the `scaffold artifacthub` command have been either removed or are no longer used.

The flag that was removed has been introduced with the 1.22.1 patch release, and is probably used only by the Kubewarden team. It was required to publish the rego policies from the monorepo.
