### PR TITLE
feat: scaffold artifacthub runs without params

### DIFF
--- a/cli-docs.md
+++ b/cli-docs.md
@@ -388,7 +388,7 @@ Scaffold an AdmissionRequest object
 
 Output an artifacthub-pkg.yml file from a metadata.yml file
 
-**Usage:** `kwctl scaffold artifacthub [OPTIONS] --metadata-path <PATH>`
+**Usage:** `kwctl scaffold artifacthub [OPTIONS]`
 
 ###### **Options:**
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -419,7 +419,6 @@ fn subcommand_scaffold() -> Command {
         Arg::new("metadata-path")
             .long("metadata-path")
             .short('m')
-            .required(true)
             .value_name("PATH")
             .help("File containing the metadata of the policy"),
         Arg::new("version")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,6 +92,13 @@ pub(crate) fn new_policy_execution_mode_from_str(name: &str) -> Result<PolicyExe
     Ok(execution_mode)
 }
 
+pub(crate) fn find_file_matching_file(possible_names: &[&str]) -> Option<PathBuf> {
+    possible_names
+        .iter()
+        .map(PathBuf::from)
+        .find(|path| path.exists())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/tests/data/artifacthub/metadata.yml
+++ b/tests/data/artifacthub/metadata.yml
@@ -1,0 +1,188 @@
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - apiextensions.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - apiregistration.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - apps
+    apiVersions:
+      - v1beta1
+      - v1beta2
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - audit.k8s.io
+    apiVersions:
+      - v1alpha1
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - authentication.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - autoscaling
+    apiVersions:
+      - v2beta1
+      - v2beta2
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - batch
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - certificates.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - coordination.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - discovery.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - events.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - extensions
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - flowcontrol.apiserver.k8s.io
+    apiVersions:
+      - v1beta1
+      - v1beta2
+      - v1beta3
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - networking.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - node.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - policy
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    apiVersions:
+      - v1alpha1
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - scheduling.k8s.io
+    apiVersions:
+      - v1alpha1
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+  - apiGroups:
+      - storage.k8s.io
+    apiVersions:
+      - v1beta1
+    resources:
+      - "*"
+    operations:
+      - CREATE
+mutating: false
+contextAware: false
+executionMode: kubewarden-wapc
+backgroundAudit: false
+annotations:
+  # artifacthub specific
+  io.artifacthub.displayName: Deprecated API Versions
+  io.artifacthub.resources: "*"
+  io.artifacthub.keywords: compliance, deprecated API
+  io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/deprecated-api-versions
+  # kubewarden specific
+  io.kubewarden.policy.title: deprecated-api-versions
+  io.kubewarden.policy.description: Find deprecated and removed Kubernetes resources
+  io.kubewarden.policy.version: 0.2.0
+  io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
+  io.kubewarden.policy.url: https://github.com/kubewarden/deprecated-api-versions-policy
+  io.kubewarden.policy.source: https://github.com/kubewarden/deprecated-api-versions-policy
+  io.kubewarden.policy.license: Apache-2.0
+  io.kubewarden.policy.category: Kubernetes API Versions
+  io.kubewarden.policy.severity: low

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -575,6 +575,45 @@ fn test_inspect_policy_yml_output(#[case] show_signatures: bool) {
     assert_eq!(show_signatures, report.contains_key("signatures"))
 }
 
+#[test]
+fn test_artifacthub_scaffold_find_metadata_automatically() {
+    let tempdir = tempdir().unwrap();
+
+    std::fs::copy(
+        test_data("artifacthub/metadata.yml"),
+        tempdir.path().join("metadata.yml"),
+    )
+    .expect("cannot copy metadata.yml");
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("scaffold").arg("artifacthub");
+
+    cmd.assert().success();
+}
+
+#[test]
+fn test_artifacthub_scaffold_with_custom_metadata() {
+    let tempdir = tempdir().unwrap();
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("scaffold")
+        .arg("artifacthub")
+        .arg("--metadata-path")
+        .arg(test_data("artifacthub/metadata.yml"));
+
+    cmd.assert().success();
+}
+
+#[test]
+fn test_artifacthub_scaffold_fail_when_metadata_not_provided_nor_found() {
+    let tempdir = tempdir().unwrap();
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("scaffold").arg("artifacthub");
+
+    cmd.assert().failure();
+}
+
 fn get_wasm_annotations(dir: &Path, oci_ref: &str) -> Result<BTreeMap<String, String>> {
     let mut cmd = setup_command(dir);
     cmd.arg("inspect").arg(oci_ref).arg("-o").arg("yaml");


### PR DESCRIPTION
Let the `scaffold artifacthub` run also without having the user provide the path to the `metadata.yml` and to the questions file.

The user can still provide these values as flags, but when they are not provided we will search for them using standard locations.

This is required as part of https://github.com/kubewarden/kubewarden-controller/issues/956
