### PR TITLE
fix(cli): correct quotation marks with normal qutations.

### DIFF
--- a/cli-docs.md
+++ b/cli-docs.md
@@ -102,9 +102,9 @@ Benchmarks a Kubewarden policy
 * `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
 * `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
-* `--measurement-time <SECONDS>` — How long the bench ‘should’ run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed
+* `--measurement-time <SECONDS>` — How long the bench 'should' run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed
 * `--num-resamples <NUM>` — How many resamples should be done
-* `--num-samples <NUM>` — How many resamples should be done. Recommended at least 50, above 100 doesn’t seem to yield a significantly different result
+* `--num-samples <NUM>` — How many resamples should be done. Recommended at least 50, above 100 doesn't seem to yield a significantly different result
 * `--raw <RAW>` — Validate a raw request
 
   Default value: `false`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -567,7 +567,7 @@ fn subcommand_bench() -> Command {
             .long("measurement-time")
             .number_of_values(1)
             .value_name("SECONDS")
-            .help("How long the bench ‘should’ run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed"),
+            .help("How long the bench 'should' run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed"),
         Arg::new("num_resamples")
             .long("num-resamples")
             .number_of_values(1)
@@ -577,7 +577,7 @@ fn subcommand_bench() -> Command {
             .long("num-samples")
             .number_of_values(1)
             .value_name("NUM")
-            .help("How many resamples should be done. Recommended at least 50, above 100 doesn’t seem to yield a significantly different result"),
+            .help("How many resamples should be done. Recommended at least 50, above 100 doesn't seem to yield a significantly different result"),
         Arg::new("warm_up_time")
             .long("warm-up-time")
             .number_of_values(1)


### PR DESCRIPTION
## Description

exchange the quotations with a normal single quotations .

Fix #1151 
