### PR TITLE
fix(ci): build on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,14 @@ jobs:
 
       - name: enable git long paths on Windows
         if: matrix.os == 'windows-latest'
-        run: git config --global core.longpaths true
+        run: |
+          echo 'CMAKE_POLICY_VERSION_MINIMUM="3.5"' >> $GITHUB_ENV
+
+      # aws-lc-sys CMakefile contains a directive that has been removed from
+      # cmake v4 that has just been released (march 2025). The build failure
+      # can be fixed by setting an environment variable
+      - name: fix aws-lc-sys building with cmake 4.0.0
+        run: set CMAKE_POLICY_VERSION_MINIMUM="3.5"
 
       - name: Build kwctl
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,30 @@ env:
 jobs:
   check:
     name: Cargo check
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - name: enable git long paths on Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --global core.longpaths true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           profile: minimal
           toolchain: stable
           override: true
+
+      # aws-lc-sys CMakefile contains a directive that has been removed from
+      # cmake v4 that has just been released (march 2025). The build failure
+      # can be fixed by setting an environment variable
+      - name: fix aws-lc-sys building with cmake 4.0.0
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo 'CMAKE_POLICY_VERSION_MINIMUM="3.5"' >> $GITHUB_ENV
+
       - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: check


### PR DESCRIPTION
This PR introduces two changes.

## Fix windows builds

Address the build failure currently happening on windows (fixes https://github.com/kubewarden/kwctl/issues/1162).

The GitHub runners based on Windows are now using latest version of CMake (v4).

The aws-lc-sys crate builds itself using cmake, but contains a directive that has been removed from v4.
To fix the build issue, an environment variable has to be set.

## Detect OS-related issues earlier

Run `cargo check` against windows, linux and macos. This allows us to spot issues earlier, during a PR.

Otherwise the OS-related failures are going to be visible only after PRs are merged and the `build` workflow is triggered.