### PR TITLE
ci: Substitute peter-evans/repository-dispatch with gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,17 @@ jobs:
             });
 
       - name: Trigger chart update
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
-        with:
-          token: ${{ secrets.WORKFLOW_PAT }}
-          repository: "${{github.repository_owner}}/helm-charts"
-          event-type: update-chart
-          client-payload: '{"version": "${{ github.ref_name }}", "oldVersion": "${{ steps.get_last_release_tag.outputs.old_release_tag }}", "repository": "${{ github.repository }}"}'
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          echo '{
+            "event_type": "update-chart",
+            "client_payload": {
+              "version": "${{ github.ref_name }}",
+              "oldVersion": "${{ steps.get_last_release_tag.outputs.old_release_tag }}",
+              "repository": "${{ github.repository }}"
+            }
+          }' > payload.json
+          gh api repos/${{ github.repository_owner }}/helm-charts/dispatches \
+            -X POST \
+            --input payload.json


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/kubewarden-controller/issues/1099.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Tagged a `v1.24.0-viccuad` from my fork, which run:
<!-- Please provides a short description about how to test your pullrequest -->
https://github.com/viccuad/kwctl/actions/runs/14729543239

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
