### PR TITLE
chore(deps): add rust-toolchain.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,6 @@ jobs:
       - name: checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: setup rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          toolchain: stable
-          target: ${{matrix.targetarch}}-unknown-linux-musl
-          override: true
-
       - name: Install cross-rs
         run: |
           set -e
@@ -128,13 +121,6 @@ jobs:
 
       - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
-      - name: Setup rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          toolchain: stable
-          target: ${{ matrix.targetarch }}-apple-darwin
-          override: true
-
       - run: rustup target add ${{ matrix.targetarch }}-apple-darwin
 
       - name: Build kwctl
@@ -210,12 +196,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
-
-      - name: Setup rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          toolchain: stable
-      - run: rustup target add x86_64-pc-windows-msvc
 
       - name: enable git long paths on Windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/update-rust-toolchain.yaml
+++ b/.github/workflows/update-rust-toolchain.yaml
@@ -1,0 +1,26 @@
+name: Update rust-toolchain
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 3 * * 1" # 3:30 on Monday
+
+jobs:
+  update-rust-toolchain:
+    name: Update Rust toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@ae3030ce1710c6496214fb1f8fd3bd9437b2a69d # v2.82.0
+
+      - name: Update rust version inside of rust-toolchain file
+        id: update_rust_toolchain
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: |-
+          updatecli apply --config ./updatecli/updatecli.d/update-rust-toolchain.yaml \
+                    --values updatecli/values.yaml

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+[toolchain]
+channel = "1.86.0"
+components = ["clippy", "rust-analyzer", "rustfmt"]
+profile = "minimal"
+targets = [
+  "aarch64-apple-darwin",
+  "aarch64-unknown-linux-musl",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-musl",
+]

--- a/updatecli/DEVELOP.md
+++ b/updatecli/DEVELOP.md
@@ -1,0 +1,6 @@
+To test the updatecli manifests locally:
+
+```console
+export UPDATECLI_GITHUB_TOKEN=<your token>
+UPDATECLI_GITHUB_OWNER=<your user> updatecli diff --config updatecli/updatecli.d/update-rust-toolchain.yaml --values updatecli/values.yaml
+```

--- a/updatecli/updatecli.d/update-rust-toolchain.yaml
+++ b/updatecli/updatecli.d/update-rust-toolchain.yaml
@@ -1,0 +1,45 @@
+name: Update Rust version inside of rust-toolchain file
+
+scms:
+  github:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "kwctl"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitusingapi: true # enable cryptographically signed commits
+      commitmessage:
+        hidecredit: true
+
+sources:
+  rust-lang:
+    name: Get the latest release of Rust from rust-lang
+    kind: githubrelease
+    spec:
+      owner: rust-lang
+      repository: rust
+      token: "{{ requiredEnv .github.token }}"
+      versionfilter:
+        kind: semver
+        pattern: "*"
+
+targets:
+  dataFile:
+    name: 'deps(rust): update Rust version to {{ source "rust-lang" }}'
+    kind: toml
+    scmid: github
+    spec:
+      file: "rust-toolchain.toml"
+      key: toolchain.channel
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: github
+    spec:
+      labels:
+        - kind/chore

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,7 @@
+github:
+  owner: "UPDATECLI_GITHUB_OWNER"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  author: "Kubewarden bot"
+  email: "cncf-kubewarden-maintainers@lists.cncf.io"
+  user: "UPDATECLI_GITHUB_OWNER"


### PR DESCRIPTION
## Description

Adds the rust-toolchain.toml file to configure the build command on witch toolchain and target it should use.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1093
