### PR TITLE
chore: prepare for v1.26.0-rc1 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.25.0"
+version = "1.26.0-rc1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors     = ["Kubewarden Developers <kubewarden@suse.de>"]
 description = "Tool to manage Kubewarden policies"
 edition     = "2021"
 name        = "kwctl"
-version     = "1.25.0"
+version     = "1.26.0-rc1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Description

Bump the version in Cargo files in preparation to the v1.26.0-rc1 release.
