### PR TITLE
build: Bump version to 1.27.0-alpha3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.27.0-alpha2"
+version = "1.27.0-alpha3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors     = ["Kubewarden Developers <kubewarden@suse.de>"]
 description = "Tool to manage Kubewarden policies"
 edition     = "2021"
 name        = "kwctl"
-version     = "1.27.0-alpha2"
+version     = "1.27.0-alpha3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This consumes the latests changes to the `can_i` host capability from policy-evaluator.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI.

Will fail until policy-evaluator 0.27.2 is released.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
