### PR TITLE
chore: update cargo-audit exceptions

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -11,9 +11,6 @@ ignore = [
   "RUSTSEC-2023-0071", # "Classic" RSA timing sidechannel attack from non-constant-time implementation.
   # Okay for local use.
   # https://rustsec.org/advisories/RUSTSEC-2023-0071.html
-  "RUSTSEC-2023-0081", # This is about `safemem` being unmaintained.
-  # This is a transitive dependency of syntect. This bug is tracked upstream inside of
-  # https://github.com/trishume/syntect/issues/521
-  "RUSTSEC-2024-0370", # This is a warning about `proc-macro-errors` being unmaintained. It's a transitive dependency of `sigstore` and `oci-spec`.
   "RUSTSEC-2023-0055", # This is a warning about `lexical` having multiple soundness issues. It's a transitive dependency of `sigstore`.
+  "RUSTSEC-2024-0370", # This is a warning about `proc-macro-errors` being unmaintained. It's a transitive dependency of `sigstore` and `oci-spec`.
 ]


### PR DESCRIPTION
Do no longer ignore the `RUSTSEC-2023-0081` issue. The transitive dependency has been updated.
