### PR TITLE
fix: Don't fail when PolicyGroup has policies with differing execution modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.27.2"
+version = "1.27.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors     = ["Kubewarden Developers <cncf-kubewarden-maintainers@lists.cncf.io
 description = "Tool to manage Kubewarden policies"
 edition     = "2021"
 name        = "kwctl"
-version     = "1.27.2"
+version     = "1.27.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/command/run/evaluator.rs
+++ b/src/command/run/evaluator.rs
@@ -158,8 +158,29 @@ impl Evaluator {
                 );
 
                 for (member_id, member) in policy_members {
+                    let metadata = local_data.metadata(&member.uri);
+
+                    let execution_mode = match &member.user_execution_cfg {
+                        PolicyExecutionConfiguration::UserDefined(_mode) => {
+                            // the user cannot set the mode for members of the PolicyGroup, we
+                            // always read the mode from the metadata when creating the member
+                            unreachable!("UserDefined execution mode for PolicyGroup member should never occur");
+                        }
+                        PolicyExecutionConfiguration::PolicyDefined => {
+                            let wasm_path = local_data.local_path(&member.uri)?;
+                            determine_execution_mode(
+                                metadata,
+                                None,
+                                BackendDetector::default(),
+                                wasm_path,
+                            )?
+                        }
+                    };
+
                     let mut policy_evaluator_builder = PolicyEvaluatorBuilder::new()
-                        .policy_file(local_data.local_path(&member.uri)?)?;
+                        .policy_file(local_data.local_path(&member.uri)?)?
+                        .execution_mode(execution_mode);
+
                     if cfg.enable_wasmtime_cache {
                         policy_evaluator_builder = policy_evaluator_builder.enable_wasmtime_cache();
                     }

--- a/src/config/policy_definition.rs
+++ b/src/config/policy_definition.rs
@@ -132,6 +132,7 @@ pub(crate) enum ContextAwareConfiguration {
 pub(crate) struct PolicyMember {
     pub uri: String,
     pub settings: PolicyGroupMemberSettings,
+    pub user_execution_cfg: PolicyExecutionConfiguration,
 }
 
 /// Converts a Kubewarden CRD AdmissionPolicy into a PolicyDefinition.
@@ -223,7 +224,14 @@ impl TryFrom<ClusterAdmissionPolicyGroup> for PolicyDefinition {
             let settings: PolicyGroupMemberSettings =
                 policy.try_into().map_err(anyhow::Error::msg)?;
 
-            policy_members.insert(policy_id.clone(), PolicyMember { uri, settings });
+            policy_members.insert(
+                policy_id.clone(),
+                PolicyMember {
+                    uri,
+                    settings,
+                    user_execution_cfg: PolicyExecutionConfiguration::PolicyDefined,
+                },
+            );
         }
 
         let policy_mode = spec.mode.unwrap_or_default().into();
@@ -256,7 +264,14 @@ impl TryFrom<AdmissionPolicyGroup> for PolicyDefinition {
             let settings: PolicyGroupMemberSettings =
                 policy.try_into().map_err(anyhow::Error::msg)?;
 
-            policy_members.insert(policy_id.clone(), PolicyMember { uri, settings });
+            policy_members.insert(
+                policy_id.clone(),
+                PolicyMember {
+                    uri,
+                    settings,
+                    user_execution_cfg: PolicyExecutionConfiguration::PolicyDefined,
+                },
+            );
         }
 
         let policy_mode = spec.mode.unwrap_or_default().into();
@@ -667,6 +682,7 @@ mod tests {
                                 .expect("Failed to convert settings for member 1"),
                             ctx_aware_resources_allow_list: pgm_1_expected_context_aware_resources,
                         },
+                        user_execution_cfg: PolicyExecutionConfiguration::PolicyDefined,
                     },
                 ),
                 (
@@ -678,6 +694,7 @@ mod tests {
                                 .expect("Failed to convert settings for member 2"),
                             ctx_aware_resources_allow_list: BTreeSet::new(),
                         },
+                        user_execution_cfg: PolicyExecutionConfiguration::PolicyDefined,
                     },
                 ),
             ]),


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kwctl/issues/1318

When building the evaluators of the members of the PolicyGroup,
propagate the PolicyExecutionConfiguration from the member metadata.

Previously, we were assuming all PolicyExecutionConfiguration were the
same. This fixes the bug were the PolicyGroup has members with differing
execution configurations, such a Rust Wasm module and an OPA Wasm
module.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added an e2e test.

Tried to add a unit test for `Evaluator::new()`, but the amount of scaffolding is quite big, to the point that we would be basically mocking the whole Evaluator creation. Here is a try:

<details>

 <summary>Click me</summary>

```rust
    #[tokio::test(flavor = "multi_thread")]
    async fn test_policy_member_execution_mode_selection() {
        use crate::config::policy_definition::{PolicyExecutionConfiguration, PolicyMember};
        use policy_evaluator::policy_group_evaluator::PolicyGroupMemberSettings;
        use std::collections::HashMap;

        // Create a dummy PolicyGroup with one member
        let member_id = "member1".to_string();
        let member = PolicyMember {
            uri: "dummy_policy.wasm".to_string(), // <- the wasm metadata contains the execution mode
            settings: PolicyGroupMemberSettings::default(),
            user_execution_cfg: PolicyExecutionConfiguration::PolicyDefined,
        };
        let mut policy_members = HashMap::new();
        policy_members.insert(member_id.clone(), member.clone());

        let policy_group = crate::config::policy_definition::PolicyDefinition::PolicyGroup {
            id: "group1".to_string(),
            policy_mode:
                policy_evaluator::admission_response_handler::policy_mode::PolicyMode::Protect,
            policy_members: policy_members.clone(),
            expression: "true".to_string(),
            message: "msg".to_string(),
        };

        let cfg = crate::config::pull_and_run::PullAndRunSettings::default();
        let local_data = crate::command::run::local_data::LocalData::default(); // <- mock missing.

        let (evaluator, _, _) = Evaluator::new(&policy_group, &cfg, &local_data) // <- determine_execution_mode() mock missing
            .await
            .expect("Evaluator::new should succeed");

        if let Evaluator::GroupPolicy { .. } = evaluator {
            for member in policy_members.values() {
                assert!(matches!(
                    member.user_execution_cfg,
                    PolicyExecutionConfiguration::PolicyDefined
                ));
            }
        } else {
            panic!("Expected GroupPolicy variant");
        }
    }
```
</detail>

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
