### PR TITLE
fix js policies built with latest javy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors     = ["Kubewarden Developers <cncf-kubewarden-maintainers@lists.cncf.io>"]
 description = "Tool to manage Kubewarden policies"
-edition     = "2021"
+edition     = "2024"
 name        = "kwctl"
 version     = "1.29.0"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,12 @@
 
 [toolchain]
-  channel = "1.87.0"
-  components = ["clippy", "rust-analyzer", "rustfmt"]
-  profile = "minimal"
-  targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-musl"]
+channel = "1.90.0"
+components = ["clippy", "rust-analyzer", "rustfmt"]
+profile = "minimal"
+targets = [
+  "aarch64-apple-darwin",
+  "aarch64-unknown-linux-musl",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-musl",
+]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,9 +1,8 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use lazy_static::lazy_static;
 use policy_evaluator::{
-    evaluation_context::EvaluationContext, policy_evaluator::PolicyExecutionMode,
+    ProtocolVersion, evaluation_context::EvaluationContext, policy_evaluator::PolicyExecutionMode,
     policy_evaluator_builder::PolicyEvaluatorBuilder, policy_metadata::Metadata, wasmparser,
-    ProtocolVersion,
 };
 use semver::{BuildMetadata, Prerelease, Version};
 use std::path::{Path, PathBuf};
@@ -137,24 +136,25 @@ impl BackendDetector {
 /// TODO: this should not take an Option
 pub fn has_minimum_kubewarden_version(opt_metadata: Option<&Metadata>) -> Result<()> {
     if let Some(metadata) = opt_metadata
-        && let Some(minimum_kubewarden_version) = &metadata.minimum_kubewarden_version {
-            let sanitized_minimum_kubewarden_version = Version {
-                major: minimum_kubewarden_version.major,
-                minor: minimum_kubewarden_version.minor,
-                // Kubewarden stack version ignore patch version number
-                patch: 0,
-                pre: Prerelease::EMPTY,
-                build: BuildMetadata::EMPTY,
-            };
-            #[allow(clippy::to_string_in_format_args)]
-            if *KUBEWARDEN_VERSION < sanitized_minimum_kubewarden_version {
-                return Err(anyhow!(
-                    "Policy required Kubewarden version {} or greater. But it's running on {}",
-                    sanitized_minimum_kubewarden_version,
-                    KUBEWARDEN_VERSION.to_string(),
-                ));
-            }
+        && let Some(minimum_kubewarden_version) = &metadata.minimum_kubewarden_version
+    {
+        let sanitized_minimum_kubewarden_version = Version {
+            major: minimum_kubewarden_version.major,
+            minor: minimum_kubewarden_version.minor,
+            // Kubewarden stack version ignore patch version number
+            patch: 0,
+            pre: Prerelease::EMPTY,
+            build: BuildMetadata::EMPTY,
+        };
+        #[allow(clippy::to_string_in_format_args)]
+        if *KUBEWARDEN_VERSION < sanitized_minimum_kubewarden_version {
+            return Err(anyhow!(
+                "Policy required Kubewarden version {} or greater. But it's running on {}",
+                sanitized_minimum_kubewarden_version,
+                KUBEWARDEN_VERSION.to_string(),
+            ));
         }
+    }
     Ok(())
 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -136,8 +136,8 @@ impl BackendDetector {
 /// version required by the policy
 /// TODO: this should not take an Option
 pub fn has_minimum_kubewarden_version(opt_metadata: Option<&Metadata>) -> Result<()> {
-    if let Some(metadata) = opt_metadata {
-        if let Some(minimum_kubewarden_version) = &metadata.minimum_kubewarden_version {
+    if let Some(metadata) = opt_metadata
+        && let Some(minimum_kubewarden_version) = &metadata.minimum_kubewarden_version {
             let sanitized_minimum_kubewarden_version = Version {
                 major: minimum_kubewarden_version.major,
                 minor: minimum_kubewarden_version.minor,
@@ -155,7 +155,6 @@ pub fn has_minimum_kubewarden_version(opt_metadata: Option<&Metadata>) -> Result
                 ));
             }
         }
-    }
     Ok(())
 }
 

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -8,7 +8,7 @@ mod proxy;
 
 use crate::{
     callback_handler::proxy::CallbackHandlerProxy,
-    config::{pull_and_run::PullAndRunSettings, HostCapabilitiesMode},
+    config::{HostCapabilitiesMode, pull_and_run::PullAndRunSettings},
 };
 
 #[derive(Clone)]

--- a/src/callback_handler/proxy.rs
+++ b/src/callback_handler/proxy.rs
@@ -1,5 +1,5 @@
 use super::ProxyMode;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::{
     callback_handler::CallbackHandlerBuilder,
     callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse},

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use clap::{
-    builder::PossibleValuesParser, crate_authors, crate_description, crate_name, crate_version,
-    Arg, ArgAction, ArgGroup, Command,
+    Arg, ArgAction, ArgGroup, Command, builder::PossibleValuesParser, crate_authors,
+    crate_description, crate_name, crate_version,
 };
 use lazy_static::lazy_static;
 

--- a/src/cli/bench.rs
+++ b/src/cli/bench.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::ArgMatches;
 
 use crate::config::pull_and_run::{parse_policy_definitions, parse_pull_and_run_settings};

--- a/src/command/bench.rs
+++ b/src/command/bench.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Result};
-use tiny_bench::{bench_with_configuration_labeled, BenchmarkConfig};
+use anyhow::{Result, anyhow};
+use tiny_bench::{BenchmarkConfig, bench_with_configuration_labeled};
 use tracing::{debug, error};
 
 use crate::{

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::admission_response_handler::AdmissionResponseHandler;
 use tracing::{error, warn};
 
@@ -18,7 +18,9 @@ pub(crate) async fn exec(
     let local_data = LocalData::new(policy_definitions, pull_and_run_settings).await?;
 
     if policy_definitions.len() > 1 {
-        warn!("Multiple policies defined inside of the CRD file. All of them will run sequentially using the same request.");
+        warn!(
+            "Multiple policies defined inside of the CRD file. All of them will run sequentially using the same request."
+        );
     }
 
     for policy_definition in policy_definitions {

--- a/src/command/run/evaluator.rs
+++ b/src/command/run/evaluator.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, sync::Arc};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::{
     admission_request::AdmissionRequest,
     admission_response::AdmissionResponse,
@@ -20,11 +20,11 @@ use crate::{
     callback_handler::{CallbackHandler, ProxyMode},
     command::run::{local_data::LocalData, policy_execution_mode::determine_execution_mode},
     config::{
+        HostCapabilitiesMode,
         policy_definition::{
             ContextAwareConfiguration, PolicyDefinition, PolicyExecutionConfiguration,
         },
         pull_and_run::PullAndRunSettings,
-        HostCapabilitiesMode,
     },
 };
 
@@ -272,10 +272,15 @@ fn build_context_aware_allowed_resources(
     match ctx_aware_cfg {
         ContextAwareConfiguration::NoAccess => {
             if let Some(metadata) = metadata
-                && !metadata.context_aware_resources.is_empty() {
-                    warn!("Policy requires access to Kubernetes resources at evaluation time. During this execution the access to Kubernetes resources is denied. This can cause the policy to not behave properly");
-                    warn!("Carefully review which types of Kubernetes resources the policy needs via the `inspect` command, then run the policy using the `--allow-context-aware` flag.");
-                }
+                && !metadata.context_aware_resources.is_empty()
+            {
+                warn!(
+                    "Policy requires access to Kubernetes resources at evaluation time. During this execution the access to Kubernetes resources is denied. This can cause the policy to not behave properly"
+                );
+                warn!(
+                    "Carefully review which types of Kubernetes resources the policy needs via the `inspect` command, then run the policy using the `--allow-context-aware` flag."
+                );
+            }
             BTreeSet::new()
         }
         ContextAwareConfiguration::AllowList(allowed) => allowed.to_owned(),
@@ -308,8 +313,13 @@ async fn build_kube_client() -> Result<kube::Client> {
         // that is always associated to the certificate used by the API server.
         // This will make kwctl work against minikube and k3d, to name a few...
         if is_an_ip && kube_config.tls_server_name.is_none() {
-            warn!(host, "The loaded kubeconfig connects to a server using an IP address instead of a FQDN. This is usually done by minikube, k3d and other local development solutions");
-            warn!("Due to a limitation of rustls, certificate validation cannot be performed against IP addresses, the certificate validation will be made against `kubernetes.default.svc`");
+            warn!(
+                host,
+                "The loaded kubeconfig connects to a server using an IP address instead of a FQDN. This is usually done by minikube, k3d and other local development solutions"
+            );
+            warn!(
+                "Due to a limitation of rustls, certificate validation cannot be performed against IP addresses, the certificate validation will be made against `kubernetes.default.svc`"
+            );
             kube_config.tls_server_name = Some("kubernetes.default.svc".to_string());
         }
     }

--- a/src/command/run/evaluator.rs
+++ b/src/command/run/evaluator.rs
@@ -271,12 +271,11 @@ fn build_context_aware_allowed_resources(
 ) -> BTreeSet<ContextAwareResource> {
     match ctx_aware_cfg {
         ContextAwareConfiguration::NoAccess => {
-            if let Some(metadata) = metadata {
-                if !metadata.context_aware_resources.is_empty() {
+            if let Some(metadata) = metadata
+                && !metadata.context_aware_resources.is_empty() {
                     warn!("Policy requires access to Kubernetes resources at evaluation time. During this execution the access to Kubernetes resources is denied. This can cause the policy to not behave properly");
                     warn!("Carefully review which types of Kubernetes resources the policy needs via the `inspect` command, then run the policy using the `--allow-context-aware` flag.");
                 }
-            }
             BTreeSet::new()
         }
         ContextAwareConfiguration::AllowList(allowed) => allowed.to_owned(),

--- a/src/command/run/local_data.rs
+++ b/src/command/run/local_data.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::PathBuf};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::{policy_fetcher::PullDestination, policy_metadata::Metadata};
 
 use crate::{

--- a/src/command/run/policy_execution_mode.rs
+++ b/src/command/run/policy_execution_mode.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::{policy_evaluator::PolicyExecutionMode, policy_metadata::Metadata};
 
 use crate::backend::BackendDetector;
@@ -52,7 +52,9 @@ pub(crate) fn determine_execution_mode(
     // no metadata and no user execution mode provided, we can only make sure
     // that the policy is not a Rego one and then default to Kubewarden WAPC
     if is_rego_policy {
-        return Err(anyhow!("The policy has been created with Rego, please specify which Opa runtime has to be used"));
+        return Err(anyhow!(
+            "The policy has been created with Rego, please specify which Opa runtime has to be used"
+        ));
     }
 
     Ok(PolicyExecutionMode::KubewardenWapc)
@@ -76,13 +78,17 @@ fn determine_execution_mode_from_metadata(
     if (mode != PolicyExecutionMode::OpaGatekeeper && mode != PolicyExecutionMode::Opa)
         && is_rego_policy
     {
-        return Err(anyhow!("The policy has been created with Rego, the policy execution mode specified via CLI flag is wrong"));
+        return Err(anyhow!(
+            "The policy has been created with Rego, the policy execution mode specified via CLI flag is wrong"
+        ));
     }
 
     if (mode == PolicyExecutionMode::OpaGatekeeper || mode == PolicyExecutionMode::Opa)
         && !is_rego_policy
     {
-        return Err(anyhow!("The policy has not been created with Rego, the policy execution mode specified via CLI flag is wrong"));
+        return Err(anyhow!(
+            "The policy has not been created with Rego, the policy execution mode specified via CLI flag is wrong"
+        ));
     }
 
     Ok(mode)

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap_complete::{
     generate,
     shells::{Bash, Elvish, Fish, PowerShell, Zsh},

--- a/src/config/policy_definition.rs
+++ b/src/config/policy_definition.rs
@@ -4,7 +4,7 @@ use std::{
     fmt,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::ArgMatches;
 use k8s_openapi::api::core::v1::ObjectReference;
 use policy_evaluator::{

--- a/src/config/pull_and_run.rs
+++ b/src/config/pull_and_run.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::ArgMatches;
 use policy_evaluator::policy_fetcher::{
     sigstore::trust::ManualTrustRoot, sources::Sources, verify::config::LatestVerificationConfig,
@@ -17,10 +17,10 @@ use tracing::info;
 use crate::{
     callback_handler,
     config::{
+        HostCapabilitiesMode,
         policy_definition::PolicyDefinition,
         sources::remote_server_options,
         verification::{build_sigstore_trust_root, build_verification_options},
-        HostCapabilitiesMode,
     },
     verify,
 };
@@ -52,7 +52,9 @@ pub(crate) fn parse_policy_definitions(matches: &ArgMatches) -> Result<Vec<Polic
             ));
         }
         if matches.contains_id("settings-json") || matches.contains_id("settings-path") {
-            info!("The --settings-json and --settings-path options are ignored when using a YAML file");
+            info!(
+                "The --settings-json and --settings-path options are ignored when using a YAML file"
+            );
         }
 
         // If the URI is a YAML file, parse it as a policy definition

--- a/src/config/sources.rs
+++ b/src/config/sources.rs
@@ -3,7 +3,7 @@ use std::{env, path::Path};
 use anyhow::Result;
 use clap::ArgMatches;
 use policy_evaluator::policy_fetcher::{
-    sources::{read_sources_file, Sources},
+    sources::{Sources, read_sources_file},
     store::DEFAULT_ROOT,
 };
 use tracing::warn;
@@ -33,11 +33,17 @@ pub(crate) fn remote_server_options(matches: &ArgMatches) -> Result<Option<Sourc
         match docker_config_path.as_path().try_exists() {
             Ok(exist) => {
                 if !exist {
-                    warn!("Docker config file not found. Check if you are pointing to the directory containing the file. The file path should be {}.", docker_config_path.display());
+                    warn!(
+                        "Docker config file not found. Check if you are pointing to the directory containing the file. The file path should be {}.",
+                        docker_config_path.display()
+                    );
                 }
             }
             Err(_) => {
-                warn!("Docker config file not found. Check if you are pointing to the directory containing the file. The file path should be {}.", docker_config_path.display());
+                warn!(
+                    "Docker config file not found. Check if you are pointing to the directory containing the file. The file path should be {}.",
+                    docker_config_path.display()
+                );
             }
         }
     }

--- a/src/config/verification.rs
+++ b/src/config/verification.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, convert::TryInto, fs, path::Path, sync::Arc};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::ArgMatches;
 use policy_evaluator::policy_fetcher::{
     sigstore::{
@@ -8,11 +8,11 @@ use policy_evaluator::policy_fetcher::{
         trust::{ManualTrustRoot, TrustRoot},
     },
     store::DEFAULT_ROOT,
-    verify::config::{read_verification_file, LatestVerificationConfig, Signature, Subject},
+    verify::config::{LatestVerificationConfig, Signature, Subject, read_verification_file},
 };
 use tracing::{debug, info};
 
-use crate::{verify::VerificationAnnotations, KWCTL_VERIFICATION_CONFIG};
+use crate::{KWCTL_VERIFICATION_CONFIG, verify::VerificationAnnotations};
 
 pub(crate) fn build_verification_options(
     matches: &ArgMatches,

--- a/src/info.rs
+++ b/src/info.rs
@@ -3,7 +3,7 @@ use clap::crate_version;
 use itertools::Itertools;
 use policy_evaluator::{
     burrego,
-    policy_fetcher::store::{Store, DEFAULT_ROOT},
+    policy_fetcher::store::{DEFAULT_ROOT, Store},
 };
 
 pub(crate) fn info() -> Result<()> {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -5,7 +5,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use is_terminal::IsTerminal;
 use policy_evaluator::{
     constants::*,
@@ -18,14 +18,14 @@ use policy_evaluator::{
         registry::Registry,
         sigstore::{
             cosign::{ClientBuilder, CosignCapabilities},
-            registry::{oci_reference::OciReference, Auth, ClientConfig},
+            registry::{Auth, ClientConfig, oci_reference::OciReference},
         },
         sources::Sources,
     },
     policy_metadata::Metadata,
 };
-use prettytable::{format::FormatBuilder, row, Table};
-use termimad::{terminal_size, FmtText, MadSkin};
+use prettytable::{Table, format::FormatBuilder, row};
+use termimad::{FmtText, MadSkin, terminal_size};
 
 pub(crate) async fn inspect(
     uri_or_sha_prefix: &str,
@@ -43,10 +43,12 @@ pub(crate) async fn inspect(
 
     match metadata {
         Some(metadata) => metadata_printer.print(&metadata, no_color)?,
-        None => return Err(anyhow!(
-            "No Kubewarden metadata found inside of '{}'.\nPolicies can be annotated with the `kwctl annotate` command.",
-            uri
-        )),
+        None => {
+            return Err(anyhow!(
+                "No Kubewarden metadata found inside of '{}'.\nPolicies can be annotated with the `kwctl annotate` command.",
+                uri
+            ));
+        }
     };
 
     if no_signatures {
@@ -70,7 +72,9 @@ pub(crate) async fn inspect(
             {
                 println!("No sigstore signatures found");
             } else {
-                println!("Cannot determine if the policy has been signed. There was an error while attempting to fetch its signatures from the remote registry: {error} ")
+                println!(
+                    "Cannot determine if the policy has been signed. There was an error while attempting to fetch its signatures from the remote registry: {error} "
+                )
             }
         }
     }

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use flate2::read::GzDecoder;
 use policy_evaluator::policy_fetcher::store::Store;
 use std::fs::File;

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,13 +246,12 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Some("scaffold") => {
-            if let Some(matches) = matches.subcommand_matches("scaffold") {
-                if let Some(_matches) = matches.subcommand_matches("verification-config") {
+            if let Some(matches) = matches.subcommand_matches("scaffold")
+                && let Some(_matches) = matches.subcommand_matches("verification-config") {
                     println!("{}", scaffold::verification_config()?);
                 }
-            }
-            if let Some(matches) = matches.subcommand_matches("scaffold") {
-                if let Some(artifacthub_matches) = matches.subcommand_matches("artifacthub") {
+            if let Some(matches) = matches.subcommand_matches("scaffold")
+                && let Some(artifacthub_matches) = matches.subcommand_matches("artifacthub") {
                     let metadata_file = artifacthub_matches
                         .get_one::<String>("metadata-path")
                         .map(|output| PathBuf::from_str(output).unwrap())
@@ -285,14 +284,12 @@ async fn main() -> Result<()> {
                         println!("{}", content);
                     }
                 }
-            }
-            if let Some(matches) = matches.subcommand_matches("scaffold") {
-                if let Some(matches) = matches.subcommand_matches("manifest") {
+            if let Some(matches) = matches.subcommand_matches("scaffold")
+                && let Some(matches) = matches.subcommand_matches("manifest") {
                     scaffold_manifest_command(matches).await?;
                 };
-            }
-            if let Some(matches) = matches.subcommand_matches("scaffold") {
-                if let Some(matches) = matches.subcommand_matches("vap") {
+            if let Some(matches) = matches.subcommand_matches("scaffold")
+                && let Some(matches) = matches.subcommand_matches("vap") {
                     let cel_policy_uri = matches.get_one::<String>("cel-policy").unwrap();
                     let vap_file: PathBuf = matches.get_one::<String>("policy").unwrap().into();
                     let vap_binding_file: PathBuf =
@@ -304,9 +301,8 @@ async fn main() -> Result<()> {
                         vap_binding_file.as_path(),
                     )?;
                 };
-            }
-            if let Some(matches) = matches.subcommand_matches("scaffold") {
-                if let Some(matches) = matches.subcommand_matches("admission-request") {
+            if let Some(matches) = matches.subcommand_matches("scaffold")
+                && let Some(matches) = matches.subcommand_matches("admission-request") {
                     let operation: scaffold::AdmissionRequestOperation = matches
                         .get_one::<String>("operation")
                         .unwrap()
@@ -325,7 +321,6 @@ async fn main() -> Result<()> {
 
                     scaffold::admission_request(operation, object_path, old_object_path).await?;
                 };
-            }
 
             Ok(())
         }

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -1,9 +1,9 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::{
     policy_fetcher::{policy::Policy, store::Store},
     policy_metadata::Metadata as PolicyMetadata,
 };
-use prettytable::{format, row, Table};
+use prettytable::{Table, format, row};
 
 pub(crate) fn list() -> Result<()> {
     if policy_list()?.is_empty() {

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
 use policy_evaluator::policy_fetcher::{
-    fetch_policy, policy::Policy, sources::Sources, PullDestination,
+    PullDestination, fetch_policy, policy::Policy, sources::Sources,
 };
 
 pub(crate) async fn pull(

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fs, path::PathBuf};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::{
     constants::KUBEWARDEN_ANNOTATION_POLICY_SOURCE,
     policy_fetcher::{
@@ -30,7 +30,9 @@ pub(crate) async fn push(
                 return Err(anyhow!("Rego policies cannot be pushed without metadata"));
             }
         } else {
-            return Err(anyhow!("Cannot push a policy that is not annotated. Use `annotate` command or `push --force`"));
+            return Err(anyhow!(
+                "Cannot push a policy that is not annotated. Use `annotate` command or `push --force`"
+            ));
         }
     }
 
@@ -74,12 +76,13 @@ fn build_oci_annotations(annotations: BTreeMap<String, String>) -> BTreeMap<Stri
         .collect();
 
     if let Some(source) = annotations.get(KUBEWARDEN_ANNOTATION_POLICY_SOURCE)
-        && !annotations.contains_key(ORG_OPENCONTAINERS_IMAGE_SOURCE) {
-            annotations.insert(
-                ORG_OPENCONTAINERS_IMAGE_SOURCE.to_string(),
-                source.to_owned(),
-            );
-        }
+        && !annotations.contains_key(ORG_OPENCONTAINERS_IMAGE_SOURCE)
+    {
+        annotations.insert(
+            ORG_OPENCONTAINERS_IMAGE_SOURCE.to_string(),
+            source.to_owned(),
+        );
+    }
 
     debug!("OCI annotations: {:?}", annotations);
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -73,14 +73,13 @@ fn build_oci_annotations(annotations: BTreeMap<String, String>) -> BTreeMap<Stri
         .map(|(k, v)| (k.to_owned(), v.trim().to_owned()))
         .collect();
 
-    if let Some(source) = annotations.get(KUBEWARDEN_ANNOTATION_POLICY_SOURCE) {
-        if !annotations.contains_key(ORG_OPENCONTAINERS_IMAGE_SOURCE) {
+    if let Some(source) = annotations.get(KUBEWARDEN_ANNOTATION_POLICY_SOURCE)
+        && !annotations.contains_key(ORG_OPENCONTAINERS_IMAGE_SOURCE) {
             annotations.insert(
                 ORG_OPENCONTAINERS_IMAGE_SOURCE.to_string(),
                 source.to_owned(),
             );
         }
-    }
 
     debug!("OCI annotations: {:?}", annotations);
 

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::policy_fetcher::store::{PolicyPath, Store};
 use std::path::PathBuf;
 

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Result};
-use flate2::write::GzEncoder;
+use anyhow::{Result, anyhow};
 use flate2::Compression;
+use flate2::write::GzEncoder;
 use policy_evaluator::policy_fetcher::store::{PolicyPath, Store};
 use std::fs::File;
 

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -14,4 +14,4 @@ pub(crate) use artifacthub::artifacthub;
 
 mod admission_request;
 pub(crate) use admission_request::Operation as AdmissionRequestOperation;
-pub(crate) use admission_request::{admission_request, DEFAULT_KWCTL_CACHE};
+pub(crate) use admission_request::{DEFAULT_KWCTL_CACHE, admission_request};

--- a/src/scaffold/admission_request.rs
+++ b/src/scaffold/admission_request.rs
@@ -7,7 +7,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use directories::ProjectDirs;
 use k8s_openapi::{
     api::authentication::v1::UserInfo,
@@ -425,7 +425,7 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
 
-    use hyper::{http, Request, Response};
+    use hyper::{Request, Response, http};
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::{
         APIGroup, APIGroupList, APIResource, APIResourceList, GroupVersionForDiscovery,
     };
@@ -561,27 +561,33 @@ mod tests {
             .await
             .expect("catalog creation failed");
 
-        assert!(catalog
-            .lookup(&kube::api::GroupVersionKind {
-                group: "".to_string(),
-                version: "v1".to_string(),
-                kind: "Namespace".to_string()
-            })
-            .is_some());
-        assert!(catalog
-            .lookup(&kube::api::GroupVersionKind {
-                group: "".to_string(),
-                version: "v1".to_string(),
-                kind: "Service".to_string()
-            })
-            .is_some());
-        assert!(catalog
-            .lookup(&kube::api::GroupVersionKind {
-                group: "apps".to_string(),
-                version: "v1".to_string(),
-                kind: "Deployment".to_string()
-            })
-            .is_some());
+        assert!(
+            catalog
+                .lookup(&kube::api::GroupVersionKind {
+                    group: "".to_string(),
+                    version: "v1".to_string(),
+                    kind: "Namespace".to_string()
+                })
+                .is_some()
+        );
+        assert!(
+            catalog
+                .lookup(&kube::api::GroupVersionKind {
+                    group: "".to_string(),
+                    version: "v1".to_string(),
+                    kind: "Service".to_string()
+                })
+                .is_some()
+        );
+        assert!(
+            catalog
+                .lookup(&kube::api::GroupVersionKind {
+                    group: "apps".to_string(),
+                    version: "v1".to_string(),
+                    kind: "Deployment".to_string()
+                })
+                .is_some()
+        );
         assert!(catalog_file.exists());
     }
 
@@ -616,20 +622,24 @@ mod tests {
             .await
             .expect("catalog creation failed");
 
-        assert!(catalog
-            .lookup(&kube::api::GroupVersionKind {
-                group: "".to_string(),
-                version: "v1".to_string(),
-                kind: "Namespace".to_string()
-            })
-            .is_some());
-        assert!(catalog
-            .lookup(&kube::api::GroupVersionKind {
-                group: "apps".to_string(),
-                version: "v1".to_string(),
-                kind: "Deployment".to_string()
-            })
-            .is_none());
+        assert!(
+            catalog
+                .lookup(&kube::api::GroupVersionKind {
+                    group: "".to_string(),
+                    version: "v1".to_string(),
+                    kind: "Namespace".to_string()
+                })
+                .is_some()
+        );
+        assert!(
+            catalog
+                .lookup(&kube::api::GroupVersionKind {
+                    group: "apps".to_string(),
+                    version: "v1".to_string(),
+                    kind: "Deployment".to_string()
+                })
+                .is_none()
+        );
         assert!(catalog_file.exists());
     }
 

--- a/src/scaffold/artifacthub.rs
+++ b/src/scaffold/artifacthub.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::{policy_artifacthub::ArtifactHubPkg, policy_metadata::Metadata};
 use std::{
     fs::{self, File},

--- a/src/scaffold/manifest.rs
+++ b/src/scaffold/manifest.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use hostname_validator::is_valid;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use policy_evaluator::{
@@ -206,11 +206,19 @@ fn generate_yaml_resource(
                     warn!(
                         "Policy has been granted access to the Kubernetes resources mentioned by its metadata."
                     );
-                    warn!("Carefully review the contents of the `contextAwareResources` attribute for abuses.");
+                    warn!(
+                        "Carefully review the contents of the `contextAwareResources` attribute for abuses."
+                    );
                 } else {
-                    warn!("Policy requires access to Kubernetes resources at evaluation time. For safety reasons, the `contextAwareResources` attribute has been left empty.");
-                    warn!("Carefully review which types of Kubernetes resources the policy needs via the `inspect` command an populate the `contextAwareResources` accordingly.");
-                    warn!("Otherwise, invoke the `scaffold` command using the `--allow-context-aware` flag.");
+                    warn!(
+                        "Policy requires access to Kubernetes resources at evaluation time. For safety reasons, the `contextAwareResources` attribute has been left empty."
+                    );
+                    warn!(
+                        "Carefully review which types of Kubernetes resources the policy needs via the `inspect` command an populate the `contextAwareResources` accordingly."
+                    );
+                    warn!(
+                        "Otherwise, invoke the `scaffold` command using the `--allow-context-aware` flag."
+                    );
 
                     scaffold_data.metadata.context_aware_resources = BTreeSet::new();
                 }
@@ -311,8 +319,8 @@ mod tests {
     }
 
     #[test]
-    fn get_policy_title_from_cli_or_metadata_returns_title_from_annotation_if_name_from_cli_not_present(
-    ) {
+    fn get_policy_title_from_cli_or_metadata_returns_title_from_annotation_if_name_from_cli_not_present()
+     {
         let policy_title = "title";
         assert_eq!(
             Some(policy_title.to_string()),

--- a/src/scaffold/vap.rs
+++ b/src/scaffold/vap.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use k8s_openapi::api::admissionregistration::v1::{
     ValidatingAdmissionPolicy, ValidatingAdmissionPolicyBinding,
 };
@@ -50,10 +50,14 @@ fn convert_vap_to_cluster_admission_policy(
 ) -> anyhow::Result<ClusterAdmissionPolicy> {
     let vap_spec = vap.spec.unwrap_or_default();
     if vap_spec.audit_annotations.is_some() {
-        warn!("auditAnnotations are not supported by Kubewarden's CEL policy yet. They will be ignored.");
+        warn!(
+            "auditAnnotations are not supported by Kubewarden's CEL policy yet. They will be ignored."
+        );
     }
     if vap_spec.match_conditions.is_some() {
-        warn!("matchConditions are not supported by Kubewarden's CEL policy yet. They will be ignored.");
+        warn!(
+            "matchConditions are not supported by Kubewarden's CEL policy yet. They will be ignored."
+        );
     }
     if vap_spec.param_kind.is_some() {
         // It's not safe to skip this, the policy will definitely not work.
@@ -181,10 +185,12 @@ mod tests {
         assert!(!cluster_admission_policy.spec.mutating);
         assert_eq!(cluster_admission_policy.spec.rules, expected_rules);
         assert!(cluster_admission_policy.spec.background_audit);
-        assert!(cluster_admission_policy
-            .spec
-            .context_aware_resources
-            .is_empty());
+        assert!(
+            cluster_admission_policy
+                .spec
+                .context_aware_resources
+                .is_empty()
+        );
         assert_eq!(
             vap.clone().spec.unwrap().failure_policy,
             cluster_admission_policy.spec.failure_policy
@@ -223,10 +229,12 @@ mod tests {
                 cluster_admission_policy.spec.settings["variables"]
             );
         } else {
-            assert!(!cluster_admission_policy
-                .spec
-                .settings
-                .contains_key("variables"));
+            assert!(
+                !cluster_admission_policy
+                    .spec
+                    .settings
+                    .contains_key("variables")
+            );
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use policy_evaluator::policy_evaluator::PolicyExecutionMode;
 use policy_evaluator::policy_fetcher::oci_client::Reference;
-use policy_evaluator::policy_fetcher::store::{errors::StoreError, Store};
+use policy_evaluator::policy_fetcher::store::{Store, errors::StoreError};
 use regex::Regex;
 use serde_json::json;
 use std::path::PathBuf;

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3,7 +3,7 @@ use policy_evaluator::policy_fetcher::{
     policy::Policy,
     sigstore::trust::ManualTrustRoot,
     sources::Sources,
-    verify::{config::LatestVerificationConfig, Verifier},
+    verify::{Verifier, config::LatestVerificationConfig},
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -887,7 +887,9 @@ fn test_scaffold_from_vap(
 #[case::wrong(
     "rego-annotate/metadata-wrong.yml",
     false,
-    contains("Error: Wrong value inside of policy's metadata for 'executionMode'. This policy has been created using Rego")
+    contains(
+        "Error: Wrong value inside of policy's metadata for 'executionMode'. This policy has been created using Rego"
+    )
 )]
 fn test_annotate_rego(
     #[case] metadata_path: &str,


### PR DESCRIPTION
Our JavaScript/TypeScript policies are written using the Javy compiler and they necessitate a custom Javy pluging to work.

The Javy plugin defines some functions used by the js VM, plus it imports the usual `host:call` function from the WebAssembly host.

Everything was working fine until the javy-plugin version `4.0.0` was released.
This release requires to build our plugin using the wasip2 target, which in turns forces the usage of the WebAssembly component model. However, at this time, the javy compiler (v7.0.0) produces wasip1 modules instead of wasm components.

Among other changes, unrelated to this commit, the intermediate usage of the component model reduces the control we have over the final name of the function that is imported from the wasm host.

As a result, the latest js policies will import the `kubewarden:javy/host:call` function instead of the traditional `host:call` one.

Here we have two options: extend policy-evaluator to handle this special case (and cause its codebase to keep around this patch forever) or simply rewrite the name of the import function.

Luckily we are already rewriting the WebAssembly module when we do `kwctl annotate` (which is a required step to run our policies).

This commit introduces few lines of code that rewrite the name of the import function of the new JS policies to match what all the other Kubewarden WASI policies are doing.

As part of this change, I updated to the latest stable release of Rust and I've switched to the 2024 edition. This allowed me to write the new code in a more concise way.

This is required by https://github.com/kubewarden/policy-sdk-js/pull/234
