### PR TITLE
chore: prepare 1.30.0-beta1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.30.1#ff8823f7552217dcd1f26e4ff4f74287221c95b2"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.30.2#aba05d47891b849ceb0212e4c237f393354a5b91"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.29.0"
+version = "1.30.0-beta1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3982,8 +3982,8 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.30.1"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.30.1#ff8823f7552217dcd1f26e4ff4f74287221c95b2"
+version = "0.30.2"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.30.2#aba05d47891b849ceb0212e4c237f393354a5b91"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors     = ["Kubewarden Developers <cncf-kubewarden-maintainers@lists.cncf.io
 description = "Tool to manage Kubewarden policies"
 edition     = "2024"
 name        = "kwctl"
-version     = "1.29.0"
+version     = "1.30.0-beta1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -24,7 +24,7 @@ k8s-openapi = { version = "0.26.0", default-features = false, features = [
 ] }
 lazy_static = "1.4.0"
 pem = "3"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.30.1" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.30.2" }
 prettytable-rs = "^0.10"
 regex = "1"
 rustls-pki-types = { version = "1", features = ["alloc"] }


### PR DESCRIPTION
This is a beta release that includes all the fixes required to run JavaScript and TypeScript policies.

Required to have a version of kwctl that can be used to test https://github.com/kubewarden/policy-sdk-js/pull/234
