### PR TITLE
fix(ci): disable new cosign signature bundle format.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,11 @@ jobs:
 
       - name: Sign kwctl
         run: |
-          cosign sign-blob --yes \
+          # We need to disable the new bundle format enabled by default since
+          # cosign v3.x.x because some verification tools (e.g. slsactl and old
+          # cosign) are not able to properly verify the signatures using this
+          # new format
+          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
             --bundle kwctl-linux-${{ matrix.targetarch }}.bundle.sigstore \
             kwctl-linux-${{ matrix.targetarch }}
 
@@ -85,7 +89,11 @@ jobs:
 
       - name: Sign SBOM file
         run: |
-          cosign sign-blob --yes \
+          # We need to disable the new bundle format enabled by default since
+          # cosign v3.x.x because some verification tools (e.g. slsactl and old
+          # cosign) are not able to properly verify the signatures using this
+          # new format
+          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
             --bundle kwctl-linux-${{ matrix.targetarch }}-sbom.spdx.bundle.sigstore \
             kwctl-linux-${{ matrix.targetarch }}-sbom.spdx
 
@@ -139,7 +147,11 @@ jobs:
 
       - name: Sign kwctl
         run: |
-          cosign sign-blob --yes \
+          # We need to disable the new bundle format enabled by default since
+          # cosign v3.x.x because some verification tools (e.g. slsactl and old
+          # cosign) are not able to properly verify the signatures using this
+          # new format
+          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
             --bundle kwctl-darwin-${{ matrix.targetarch }}.bundle.sigstore \
             kwctl-darwin-${{ matrix.targetarch }}
 
@@ -168,7 +180,11 @@ jobs:
 
       - name: Sign SBOM file
         run: |
-          cosign sign-blob --yes \
+          # We need to disable the new bundle format enabled by default since
+          # cosign v3.x.x because some verification tools (e.g. slsactl and old
+          # cosign) are not able to properly verify the signatures using this
+          # new format
+          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
             --bundle kwctl-darwin-${{ matrix.targetarch }}-sbom.spdx.bundle.sigstore \
             kwctl-darwin-${{ matrix.targetarch }}-sbom.spdx
 
@@ -224,7 +240,11 @@ jobs:
       - name: Sign kwctl
         shell: bash
         run: |
-          cosign sign-blob --yes \
+          # We need to disable the new bundle format enabled by default since
+          # cosign v3.x.x because some verification tools (e.g. slsactl and old
+          # cosign) are not able to properly verify the signatures using this
+          # new format
+          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
             --bundle kwctl-windows-x86_64.bundle.sigstore \
             kwctl-windows-x86_64.exe
 
@@ -256,7 +276,11 @@ jobs:
       - name: Sign SBOM file
         shell: bash
         run: |
-          cosign sign-blob --yes \
+          # We need to disable the new bundle format enabled by default since
+          # cosign v3.x.x because some verification tools (e.g. slsactl and old
+          # cosign) are not able to properly verify the signatures using this
+          # new format
+          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
             --bundle kwctl-windows-x86_64-sbom.spdx.bundle.sigstore \
             kwctl-windows-x86_64-sbom.spdx
 


### PR DESCRIPTION
## Description

In order to allow old cosign version and other verification tools to verify the signature it's necessary to disable the new cosign signature bundle enable by default since v3.x.x.

Fix https://github.com/kubewarden/helm-charts/issues/839
