### PR TITLE
feat(byo-pki): allow users to define their own trusted root

### DIFF
--- a/.github/actions/setup-sigstore-env/action.yaml
+++ b/.github/actions/setup-sigstore-env/action.yaml
@@ -1,0 +1,93 @@
+name: "Prepare sigstore environment"
+description: "Prepare sigstore environment for testing"
+branding:
+  icon: box
+  color: green
+runs:
+  using: "composite"
+  steps:
+    - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+    - uses: sigstore/scaffolding/actions/setup@8e9b439dcf7072c0a9e3b1653c6227c258f94202 # v0.7.31
+    - name: Initialize cosign to use local Sigstore instance
+      shell: bash
+      run: |
+        cosign initialize --mirror $TUF_MIRROR --root ./root.json
+    - name: Generate trusted-root
+      shell: bash
+      run: |
+        curl --fail -o "fulcio.pem" "$FULCIO_URL/api/v1/rootCert"
+        curl --fail -o "rekor.pub" "$REKOR_URL/api/v1/log/publicKey"
+        curl --fail -o "tsa.pem" "$TSA_URL/api/v1/timestamp/certchain"
+        kubectl get secret -o json -n tuf-system ctlog-public-key | jq -r ".data.public" | base64 -d > ctfe.pub
+        cosign trusted-root create \
+          --fulcio="url=$FULCIO_URL,certificate-chain=fulcio.pem" \
+          --rekor="url=$REKOR_URL,public-key=rekor.pub,start-time=2025-11-01T00:00:00Z" \
+          --tsa="url=$TSA_URL,certificate-chain=tsa.pem" \
+        	--ctfe="url=$CTLOG_URL,public-key=ctfe.pub,start-time=2025-11-01T00:00:00Z" \
+          --out trusted_root.json
+    - name: Generate signing-config
+      shell: bash
+      run: |
+        cosign signing-config create \
+          --fulcio="url=$FULCIO_URL,api-version=1,start-time=2024-11-01T00:00:00Z,operator=sigstore.dev" \
+          --rekor="url=$REKOR_URL,api-version=1,start-time=2024-11-01T00:00:00Z,operator=sigstore.dev" \
+          --rekor-config="ANY" \
+          --oidc-provider="url=$ISSUER_URL/auth,api-version=1,start-time=2024-11-01T00:00:00Z,operator=sigstore.dev" \
+          --tsa="url=$TSA_URL/api/v1/timestamp,api-version=1,start-time=2024-11-01T00:00:00Z,operator=sigstore.dev" \
+          --tsa-config="EXACT:1" \
+          --out signing_config.json
+    - name: "Build the trust_config.json file"
+      shell: bash
+      run: |
+        cat << EOF >trust_config.json
+        {
+          "mediaType": "application/vnd.dev.sigstore.clienttrustconfig.v0.1+json",
+          "trustedRoot": $(cat trusted_root.json),
+          "signingConfig": $(cat signing_config.json)
+        }
+        EOF
+    - name: "Build verification file"
+      shell: bash
+      run: |
+        cat << EOF >verification_config.yaml
+          apiVersion: v1
+          allOf:
+            - kind: genericIssuer
+              issuer: https://kubernetes.default.svc.cluster.local
+              subject:
+                equal: https://kubernetes.io/namespaces/default/serviceaccounts/default
+          anyOf: null
+        EOF
+    - name: "Sign policy to use in test"
+      shell: bash
+      run: |
+        # Copy a testing policy to a local registry
+        skopeo copy --dest-tls-verify=false docker://ghcr.io/kubewarden/tests/pod-privileged:v0.2.5 docker://registry.local:5000/policies/testing:latest
+        # cosign command cannot use the new bundle format because sigstore
+        # rust crate still does not support it
+        cosign sign --yes --rekor-url ${REKOR_URL} \
+          --fulcio-url ${FULCIO_URL} \
+          --allow-insecure-registry \
+          --new-bundle-format=false \
+          --use-signing-config=false \
+          --identity-token $(curl -s $ISSUER_URL) \
+          registry.local:5000/policies/testing:latest
+    - name: Verify signature to ensure that everything worked
+      shell: bash
+      run: |
+        # cosign command cannot use the new bundle format because sigstore
+        # rust crate still does not support it
+        cosign verify \
+          --new-bundle-format=false \
+          --rekor-url "${REKOR_URL}" \
+          --allow-insecure-registry \
+          --certificate-identity "https://kubernetes.io/namespaces/default/serviceaccounts/default" \
+          --certificate-oidc-issuer "https://kubernetes.default.svc.cluster.local" \
+          "registry.local:5000/policies/testing:latest"
+    - name: "Create sources.yaml to avoid https to the local registry"
+      shell: bash
+      run: |
+        cat << EOF >sources.yaml
+        insecure_sources: 
+          - registry.local:5000
+        EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,43 @@ jobs:
       - name: run e2e tests
         run: make e2e-tests
 
+  e2e-tests-sigstore-trust-config:
+    name: Test sigstore trust config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Prepare sigstore environment for testing
+        uses: ./.github/actions/setup-sigstore-env
+      - name: Run kwctl Sigstore E2E tests
+        run: make e2e-tests-sigstore
+
+  sigstore-coverage:
+    name: sigstore-e2e-coverage
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@81ee1d48d9194cdcab880cbdc7d36e87d39874cb # v2.62.45
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Prepare sigstore environment for testing
+        uses: ./.github/actions/setup-sigstore-env
+
+      - name: Generate sigstore e2e tests coverage
+        run: cargo llvm-cov --test 'sigstore' --features sigstore-testing --lcov --output-path lcov-sigstore.info
+
+      - name: Upload tests coverage to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          files: lcov-sigstore.info
+          fail_ci_if_error: true
+          name: e2e-tests-sigstore
+          verbose: true
+          token: ${{ secrets.CODECOV_ORG_TOKEN }}
+
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,6 +3032,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "sigstore_protobuf_specs",
  "tar",
  "tempfile",
  "termimad",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,7 @@ sha2           = "0.10"
 tempfile       = "3.17"
 testcontainers = { version = "0.25", features = ["blocking"] }
 tower-test     = "0.4"
+
+
+[features]
+sigstore-testing = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ reqwest = { version = "0", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
 rustls = { version = "0.23", default-features = false }
+sigstore_protobuf_specs = "0.5"
 
 [dev-dependencies]
 assert_cmd     = "2.0.14"

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ test: fmt lint
 e2e-tests:
 	cargo test --test '*'
 	
+.PHONY: e2e-tests-sigstore
+e2e-tests-sigstore:
+	cargo test --test 'sigstore' --features sigstore-testing
+	
 .PHONY: coverage
 coverage:
 	cargo llvm-cov --html

--- a/cli-docs.md
+++ b/cli-docs.md
@@ -141,6 +141,7 @@ A YAML file may contain multiple Custom Resource declarations. In this case, `kw
 * `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
 * `--settings-json <VALUE>` — JSON string containing the settings for this policy
 * `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
@@ -261,6 +262,7 @@ Pulls a Kubewarden policy from a given URI
 * `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
 * `-o`, `--output-path <PATH>` — Output file. If not provided will be downloaded to the Kubewarden store
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
@@ -370,6 +372,7 @@ A YAML file may contain multiple Custom Resource declarations. In this case, `kw
 * `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
 * `--settings-json <VALUE>` — JSON string containing the settings for this policy
 * `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
@@ -461,6 +464,7 @@ Output a Kubernetes resource manifest
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
 * `--settings-json <VALUE>` — JSON string containing the settings for this policy
 * `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `--title <VALUE>` — Policy title
 * `-t`, `--type <VALUE>` — Kubewarden Custom Resource type
@@ -514,6 +518,7 @@ Verify a Kubewarden policy from a given URI using Sigstore
 * `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
 * `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)

--- a/src/config/pull_and_run.rs
+++ b/src/config/pull_and_run.rs
@@ -96,7 +96,11 @@ pub(crate) async fn parse_pull_and_run_settings(
 
     let verification_options = build_verification_options(matches)?;
 
-    let sigstore_trust_root = match build_sigstore_trust_root().await {
+    let sigstore_trust_root = match build_sigstore_trust_root(
+        matches.get_one::<PathBuf>("sigstore-trust-config"),
+    )
+    .await
+    {
         Ok(trust_root) => trust_root,
         Err(e) => {
             if verification_options.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,9 @@ async fn main() -> Result<()> {
                 let sources = remote_server_options(matches)?;
                 let verification_options = build_verification_options(matches)?
                     .ok_or_else(|| anyhow!("could not retrieve sigstore options"))?;
-                let sigstore_trust_root = build_sigstore_trust_root().await?;
+                let sigstore_trust_root =
+                    build_sigstore_trust_root(matches.get_one::<PathBuf>("sigstore-trust-config"))
+                        .await?;
                 verify::verify(
                     uri,
                     sources.as_ref(),
@@ -407,7 +409,8 @@ async fn pull_command(
     let verification_options = build_verification_options(matches)?;
     let mut verified_manifest_digest: Option<String> = None;
     if verification_options.is_some() {
-        let sigstore_trust_root = build_sigstore_trust_root().await?;
+        let sigstore_trust_root =
+            build_sigstore_trust_root(matches.get_one::<PathBuf>("sigstore-trust-config")).await?;
         // verify policy prior to pulling if keys listed, and keep the
         // verified manifest digest:
         verified_manifest_digest = Some(
@@ -425,7 +428,8 @@ async fn pull_command(
     let policy = pull::pull(uri, sources.as_ref(), destination).await?;
 
     if verification_options.is_some() {
-        let sigstore_trust_root = build_sigstore_trust_root().await?;
+        let sigstore_trust_root =
+            build_sigstore_trust_root(matches.get_one::<PathBuf>("sigstore-trust-config")).await?;
         return verify::verify_local_checksum(
             &policy,
             sources.as_ref(),

--- a/tests/sigstore.rs
+++ b/tests/sigstore.rs
@@ -1,0 +1,52 @@
+#[cfg(feature = "sigstore-testing")]
+use common::setup_command;
+#[cfg(feature = "sigstore-testing")]
+use tempfile::tempdir;
+
+mod common;
+
+/// This test is behind a feature flag because it requires a sigstore testing environment to run
+/// properly. In CI this is done by the sigstore/scaffolding/actions/setup action and some
+/// additional configuration. Locally, one can use the script and documentation available in the
+/// same repository.
+///
+/// Furthermore, this test expects that there is a policy
+/// "registry.local:5000/policies/testing:latest" is signed with cosign in the local sigstore
+/// instance. It also expects that the sigstore trust_config.json and verification_config.yaml files
+/// are available. The trust_config.json file should contain all the information to find the
+/// local sigstore instance. It follows the ClientTrustConfig format. See the spec here:
+/// https://github.com/sigstore/protobuf-specs/blob/4d38e4482bf67c7ab86bf2f61e8d79010ac0974e/protos/sigstore_trustroot.proto#L341
+/// The verification_config.yaml file should contain the verification configuration for the policy,
+/// it can be generated using `kwctl scaffold verification-config` command. The verification
+/// options in the file should match the way the policy was signed in the local sigstore instance.
+/// The test also checks if there is a sources.yaml files. If it exists, it is copied to the temp
+/// directory and the command is run with the --sources-path argument.
+#[test]
+#[cfg(feature = "sigstore-testing")]
+fn test_sigstore_trust_config() {
+    let tempdir = tempdir().unwrap();
+    let trust_config_file = tempdir.path().join("trust_config.json");
+    std::fs::copy("trust_config.json", &trust_config_file).expect("cannot copy trust_config.json");
+    let verification_config_file = tempdir.path().join("verification_config.yaml");
+    std::fs::copy("verification_config.yaml", &verification_config_file)
+        .expect("cannot copy verification_config.yaml");
+
+    let mut cmd = setup_command(tempdir.path());
+    cmd.arg("verify")
+        .arg("--sigstore-trust-config")
+        .arg("trust_config.json")
+        .arg("--verification-config-path")
+        .arg("verification_config.yaml");
+
+    // if there is a sources.yaml file, the test consider that the registry does not support https
+    // request. Therefore, the sources file should be copied to the tempdir as well and the command
+    // should be run with the --sources-path argument.
+    if std::path::Path::new("sources.yaml").exists() {
+        let sources_file = tempdir.path().join("sources.yaml");
+        std::fs::copy("sources.yaml", &sources_file).expect("cannot copy sources.yaml");
+        cmd.arg("--sources-path").arg("sources.yaml");
+    }
+
+    cmd.arg("registry://registry.local:5000/policies/testing:latest");
+    cmd.assert().success();
+}


### PR DESCRIPTION
## Description

Adds a new `trust-config` flag to kwctl commands, allowing users to specify a path to a JSON file with the Sigstore
"application/vnd.dev.sigstore.clienttrustconfig.v0.1+json" mediaType. This ClientTrustConfig type stores the trust root configuration used to connect to a third-party Sigstore infrastructure.

With this feature, users can verify policies using their own Sigstore infrastructure instead of the upstream Sigstore components.

The new CLI flag is optional; if not specified, kwctl will continue to use the default upstream Sigstore configuration.

Fix kubewarden/kwctl#1245 


## Test

To test this feature I've used the [sigstore/scaffolding](https://github.com/sigstore/scaffolding/tree/d0a102b3edf322c9658c0e5abe94a671f49e8245) repository. It has helper scripts and documentation to spin up a full Sigstore infrastructure locally in a Kubernetes cluster. To allow you to test it as well. This is the steps:

1. Choose two Kubewarden policies artifacts to sign with cosign. One to use the upstream Sigstore infra and another to use the local infra
2. Sign and verify one of the artifacts with upstream sigstore. Something like this:
```bash
cosign sign ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest  

cosign verify ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest --certificate-identity-regexp 'https://github.com/jvanz/*' --certificate-oidc-issuer https://token.actions.githubusercontent.com

```
3. Follow the [getting started](https://github.com/sigstore/scaffolding/blob/d0a102b3edf322c9658c0e5abe94a671f49e8245/getting-started.md) documentation to launch the Sigstore infra locally
4. Sign and verify the second artifact using the local sigstore artifact
```bash
cosign sign --rekor-url $REKOR_URL --fulcio-url $FULCIO_URL --yes --allow-insecure-registry ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest  --identity-token $(curl -s $ISSUER_URL)

cosign verify --rekor-url $REKOR_URL --allow-insecure-registry ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest  --certificate-identity=https://kubernetes.io/namespaces/default/serviceaccounts/default --certificate-oidc-issuer=https://kubernetes.default.svc.cluster.local

```
>[!NOTE]
> All the variables used here are exported in the getting started documention from the Sigstore repository. 

5. Build the trusted root configuration:
```bash
cosign trusted-root create \
    --fulcio="url=$FULCIO_URL,certificate-chain=/home/jvanz/SUSE/scaffolding/fulcio.pem" \
    --rekor="url=$REKOR_URL,public-key=/home/jvanz/SUSE/scaffolding/rekor.pub,start-time=2024-01-01T00:00:00Z" \
	--tsa="url=$TSA_MIRROR,certificate-chain=/home/jvanz/SUSE/scaffolding/tsa.pem" \
	--ctfe="url=$CTLOG_MIRROR,public-key=/home/jvanz/SUSE/scaffolding/ctfe.pub,start-time=2024-01-01T00:00:00Z" \
```
>[!NOTE]
> All the variables used here are exported in the getting started documention from the Sigstore repository. Furthermore, the certificates and keys used in this command should be extracted from the Kubernetes secrets running Sigstore locally. You can extract the files with these commands:
> ```bash
> kubectl get secret -n tuf-system fulcio-pub-key -o json | jq -r ".data.cert" | base64 -d > fulcio.pem
> kubectl get secret -o json -n tuf-system rekor-pub-key | jq -r ".data.public" | base64 -d > rekor.pub
> kubectl get secret -o json -n tuf-system tsa-cert-chain | jq -r '.data."cert-chain"'  | base64 -d > tsa.pem
> kubectl get secret -o json -n tuf-system ctlog-public-key | jq -r ".data.public" | base64 -d > ctfe.pub
> ```

6. Build the ClientTrusConfig:
```json
{
  "mediaType": "application/vnd.dev.sigstore.clienttrustconfig.v0.1+json",
  "trustedRoot": { PASTE HERE THE OUTPUT OF THE PREVIOUS STEP }
}

```
7. Build the verification config file to verify signature data. See the step script for examples, use kwctl scaffold command or read the [Kubewarden docs](https://docs.kubewarden.io/howtos/security-hardening/secure-supply-chain#keyless-signature-validation)
8. Verify policies with kwctl. I've wrote a script to do that in my testing environment

```bash
set -x 

cat ./verification-config-local
cat ./verification-config-upstream
cat ./trust_config.json

echo "###### Verifying policies without trust config ######"
./target/release/kwctl --no-color verify --verification-config-path ./verification-config-upstream registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest
./target/release/kwctl --no-color verify --verification-config-path ./verification-config-upstream registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest
./target/release/kwctl --no-color verify --verification-config-path ./verification-config-local registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest
./target/release/kwctl --no-color verify --verification-config-path ./verification-config-local registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest

echo "###### Verifying policies with trust config ######"
./target/release/kwctl --no-color verify --trust-config ./trust_config.json --verification-config-path ./verification-config-upstream registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest
./target/release/kwctl --no-color verify --trust-config ./trust_config.json --verification-config-path ./verification-config-upstream registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest
./target/release/kwctl --no-color verify --trust-config ./trust_config.json --verification-config-path ./verification-config-local registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest
./target/release/kwctl --no-color verify --trust-config ./trust_config.json --verification-config-path ./verification-config-local registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest

```

This are the output

```
+ cat ./verification-config-local
# Default Kubewarden verification config
#
# With this config, the only valid policies are those signed by Kubewarden
# infrastructure.
#
# This config can be saved to its default location (for this OS) with:
#   kwctl scaffold verification-config > /home/jvanz/.config/kubewarden/verification-config.yml
#
# Providing a config in the default location enables Sigstore verification.
# See https://docs.kubewarden.io/next/howtos/security-hardening/secure-supply-chain
# for more Sigstore verification options.
apiVersion: v1
allOf:
- kind: genericIssuer
  issuer: https://kubernetes.default.svc.cluster.local
  subject:
    equal: https://kubernetes.io/namespaces/default/serviceaccounts/default
anyOf: null


+ cat ./verification-config-upstream
# Default Kubewarden verification config
#
# With this config, the only valid policies are those signed by Kubewarden
# infrastructure.
#
# This config can be saved to its default location (for this OS) with:
#   kwctl scaffold verification-config > /home/jvanz/.config/kubewarden/verification-config.yml
#
# Providing a config in the default location enables Sigstore verification.
# See https://docs.kubewarden.io/next/howtos/security-hardening/secure-supply-chain
# for more Sigstore verification options.
apiVersion: v1
allOf:
- kind: genericIssuer
  issuer: https://github.com/login/oauth
  subject:
    equal: <<REDACTED EMAIL>>
anyOf: null


+ cat ./trust_config.json
{
  "mediaType": "application/vnd.dev.sigstore.clienttrustconfig.v0.1+json",
  "trustedRoot": {
    "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
    "tlogs": [
      {
        "baseUrl": "http://rekor.rekor-system.svc:8080",
        "hashAlgorithm": "SHA2_256",
        "publicKey": {
          "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAG7HfnnxnW949IuyL/IefWDm6LPeQuA9GSCJfme74tAh68H/9YonNwW8BJ0QZr00ntt5wCg9aaj7Iv25nHFROA==",
          "keyDetails": "PKIX_ECDSA_P256_SHA_256",
          "validFor": {
            "start": "2024-01-01T00:00:00Z"
          }
        },
        "logId": {
          "keyId": "entYhHILwMbf6CqKtXPtiXqDUkjSVrRJk+KiR1mKiII="
        }
      }
    ],
    "certificateAuthorities": [
      {
        "subject": {
          "organization": "Linux Foundation"
        },
        "uri": "http://fulcio.fulcio-system.svc:8080",
        "certChain": {
          "certificates": [
            {
              "rawBytes": "MIICNjCCAd2gAwIBAgIIenk7+Dh/rCgwCgYIKoZIzj0EAwIwfjEMMAoGA1UEBhMDVVNBMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRYwFAYDVQQJEw01NDggTWFya2V0IFN0MQ4wDAYDVQQREwU1NzI3NDEZMBcGA1UEChMQTGludXggRm91bmRhdGlvbjAeFw0yNTExMTAxNDAzNDVaFw0yNjExMTAxNDAzNDVaMH4xDDAKBgNVBAYTA1VTQTETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEWMBQGA1UECRMNNTQ4IE1hcmtldCBTdDEOMAwGA1UEERMFNTcyNzQxGTAXBgNVBAoTEExpbnV4IEZvdW5kYXRpb24wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQeiBEHp5hGO/y82NqhTqyyCAMRvGz/ArMiBawi75ngddHKwboKoQdNm/e3FHVyGQZkt2ipMrn7GFfuA9JfzDWzo0UwQzAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQURKzY1DVWDz5V//3Of1RgX2ZPZNowCgYIKoZIzj0EAwIDRwAwRAIgUapirimk73s9ohqHi1ds0MvoUiXuOa0/rk7M7Ld0htICIGa4nxUXOZrIKJoNgJSu2Np/soEW8D/R2LV6zixauFWA"
            }
          ]
        },
        "validFor": {
          "start": "2025-11-10T14:03:45Z"
        }
      }
    ],
    "ctlogs": [
      {
        "baseUrl": "http://ctlog.ctlog-system.svc:8080",
        "hashAlgorithm": "SHA2_256",
        "publicKey": {
          "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY4JI4IO+mJMnuU9WcHZFJs7lWr+SPVQixrNdEHsklIw3uXUrA2glYYxTM/0Y3UouHl5Z1plL445OlZ82R8aBDg==",
          "keyDetails": "PKIX_ECDSA_P256_SHA_256",
          "validFor": {
            "start": "2024-01-01T00:00:00Z"
          }
        },
        "logId": {
          "keyId": "yI+0HJ14Xs/ty5N0rJ854O8bQrNWptT9BKS+8RnzybQ="
        }
      }
    ],
    "timestampAuthorities": [
      {
        "subject": {
          "organization": "local",
          "commonName": "Test TSA Root"
        },
        "uri": "http://tsa.tsa-system.svc:8080",
        "certChain": {
          "certificates": [
            {
              "rawBytes": "MIIBzTCCAXKgAwIBAgIUTtIX/LH3OoxQNHeysBoxD8jMrR8wCgYIKoZIzj0EAwIwMDEOMAwGA1UEChMFbG9jYWwxHjAcBgNVBAMTFVRlc3QgVFNBIEludGVybWVkaWF0ZTAeFw0yNTExMTAxNDAxMzdaFw0zNDExMTAxNDA0MzdaMDAxDjAMBgNVBAoTBWxvY2FsMR4wHAYDVQQDExVUZXN0IFRTQSBUaW1lc3RhbXBpbmcwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATIbmKGiNgPSLe9vDCfKB7gc2LRswBi/jQ5DALsBVFvF4iWeg23Ul2fEr7wpwcbKYA5XU0gf2g1impSrMUBbwYCo2owaDAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFPq64pLBh+iUx7exkRnynnhj+aGqMB8GA1UdIwQYMBaAFCeQ8xLh1xtem6eXdUrkpnWd8UVEMBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMAoGCCqGSM49BAMCA0kAMEYCIQCV4q63q2eJUI7x2oAHZIUVQurQCMhBPAhYceU9YGk8tQIhAKtQKteSjwDIaIoL07MnZSavVJ993y9gScAVit0x3L5C"
            },
            {
              "rawBytes": "MIIB0jCCAXigAwIBAgIUI2QvaC9DPLje8kOwkb4rWECkv0kwCgYIKoZIzj0EAwIwKDEOMAwGA1UEChMFbG9jYWwxFjAUBgNVBAMTDVRlc3QgVFNBIFJvb3QwHhcNMjUxMTEwMTM1OTM3WhcNMzUxMTEwMTQwNDM3WjAwMQ4wDAYDVQQKEwVsb2NhbDEeMBwGA1UEAxMVVGVzdCBUU0EgSW50ZXJtZWRpYXRlMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEp+P7hnNiCXEfnmesx1fDVO3erQzcCBkcOgYuDURpI7G00ekSki9j8Y//LygH9c7oRbRpyw3GQHZlNGwJEyCWFqN4MHYwDgYDVR0PAQH/BAQDAgEGMBMGA1UdJQQMMAoGCCsGAQUFBwMIMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFCeQ8xLh1xtem6eXdUrkpnWd8UVEMB8GA1UdIwQYMBaAFJYOHWV79+SGBJnku8pEFBKJhlJGMAoGCCqGSM49BAMCA0gAMEUCIQDRwHHWthFl12BnntXW0nzHJ8j1hM+Bh0a0D/cA+hwf0AIgBw+6dtNKdMNTUdAfOYdwc/gvYFPdeg2NfZbuyK/yXeA="
            },
            {
              "rawBytes": "MIIBlDCCATqgAwIBAgIUdD6OeHGFp8prgLgQexF6p2cOqvswCgYIKoZIzj0EAwIwKDEOMAwGA1UEChMFbG9jYWwxFjAUBgNVBAMTDVRlc3QgVFNBIFJvb3QwHhcNMjUxMTEwMTM1OTM3WhcNMzUxMTEwMTQwNDM3WjAoMQ4wDAYDVQQKEwVsb2NhbDEWMBQGA1UEAxMNVGVzdCBUU0EgUm9vdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPW8JureaHsT+JFo3Um8awLhVHZySn5WrBXGt6RNsURobtNwQNpqH3gC6j/1BJPM4zbaE2fT3hqxppnA4l4p/q2jQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSWDh1le/fkhgSZ5LvKRBQSiYZSRjAKBggqhkjOPQQDAgNIADBFAiASw02tYxj2iYYe8ip7teMll7Eoe9KSdY06dZFsEyhwEAIhAKqiRkJbCmu0aAo8n8nhAc/7j+pF0YNEfDgpwp7pTBZR"
            }
          ]
        },
        "validFor": {
          "start": "2025-11-10T14:01:37Z"
        }
      }
    ]
  }
}
+ echo '###### Verifying policies without trust config ######'
###### Verifying policies without trust config ######
+ ./target/release/kwctl --no-color verify --verification-config-path ./verification-config-upstream registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest
2025-11-10T19:22:55.946655Z  INFO sigstore::cosign::client_builder: Cannot parse Rekor public key with id cf1199155bddd051268d1f16ac5c0c75c009f6fb5a63f4177f8e18d7051e3fa0: Pkcs8 spki error : Ecdsa-P256 from der bytes to public key failed: unknown/unsupported algorithm OID: 1.2.840.10045.2.1
2025-11-10T19:22:59.438902Z  INFO kwctl::verify: Policy successfully verified
+ ./target/release/kwctl --no-color verify --verification-config-path ./verification-config-upstream registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest
2025-11-10T19:23:03.298892Z  INFO sigstore::cosign::client_builder: Cannot parse Rekor public key with id cf1199155bddd051268d1f16ac5c0c75c009f6fb5a63f4177f8e18d7051e3fa0: Pkcs8 spki error : Ecdsa-P256 from der bytes to public key failed: unknown/unsupported algorithm OID: 1.2.840.10045.2.1
2025-11-10T19:23:06.788748Z  INFO sigstore::cosign::signature_layers: Skipping OCI layer because of error error=RekorPublicKeyNotFoundError("7a7b5884720bc0c6dfe82a8ab573ed897a835248d256b44993e2a247598a8882")
Error: Policy registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest cannot be validated
failed to get image trusted layers: No Signature Layer passed verification

Caused by:
    No Signature Layer passed verification
+ ./target/release/kwctl --no-color verify --verification-config-path ./verification-config-local registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest
2025-11-10T19:23:10.864568Z  INFO sigstore::cosign::client_builder: Cannot parse Rekor public key with id cf1199155bddd051268d1f16ac5c0c75c009f6fb5a63f4177f8e18d7051e3fa0: Pkcs8 spki error : Ecdsa-P256 from der bytes to public key failed: unknown/unsupported algorithm OID: 1.2.840.10045.2.1
Error: Policy registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest cannot be validated
Image verification failed: missing signatures
The following constraints were not satisfied:
kind: genericIssuer
issuer: https://kubernetes.default.svc.cluster.local
subject: !equal https://kubernetes.io/namespaces/default/serviceaccounts/default
annotations: null

+ ./target/release/kwctl --no-color verify --verification-config-path ./verification-config-local registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest
2025-11-10T19:23:18.529628Z  INFO sigstore::cosign::client_builder: Cannot parse Rekor public key with id cf1199155bddd051268d1f16ac5c0c75c009f6fb5a63f4177f8e18d7051e3fa0: Pkcs8 spki error : Ecdsa-P256 from der bytes to public key failed: unknown/unsupported algorithm OID: 1.2.840.10045.2.1
2025-11-10T19:23:21.917290Z  INFO sigstore::cosign::signature_layers: Skipping OCI layer because of error error=RekorPublicKeyNotFoundError("7a7b5884720bc0c6dfe82a8ab573ed897a835248d256b44993e2a247598a8882")
Error: Policy registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest cannot be validated
failed to get image trusted layers: No Signature Layer passed verification

Caused by:
    No Signature Layer passed verification
+ echo '###### Verifying policies with trust config ######'
###### Verifying policies with trust config ######
+ ./target/release/kwctl --no-color verify --trust-config ./trust_config.json --verification-config-path ./verification-config-upstream registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest
2025-11-10T19:23:25.385336Z  INFO sigstore::cosign::signature_layers: Skipping OCI layer because of error error=RekorPublicKeyNotFoundError("c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d")
Error: Policy registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest cannot be validated
failed to get image trusted layers: No Signature Layer passed verification

Caused by:
    No Signature Layer passed verification
+ ./target/release/kwctl --no-color verify --trust-config ./trust_config.json --verification-config-path ./verification-config-upstream registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest
Error: Policy registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest cannot be validated
Image verification failed: missing signatures
The following constraints were not satisfied:
kind: genericIssuer
issuer: https://github.com/login/oauth
subject: !equal jvanz@jvanz.com
annotations: null

+ ./target/release/kwctl --no-color verify --trust-config ./trust_config.json --verification-config-path ./verification-config-local registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest
2025-11-10T19:23:32.272828Z  INFO sigstore::cosign::signature_layers: Skipping OCI layer because of error error=RekorPublicKeyNotFoundError("c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d")
Error: Policy registry://ghcr.io/jvanz/policies/testing-sigstore-upstreaminfra:latest cannot be validated
failed to get image trusted layers: No Signature Layer passed verification

Caused by:
    No Signature Layer passed verification
+ ./target/release/kwctl --no-color verify --trust-config ./trust_config.json --verification-config-path ./verification-config-local registry://ghcr.io/jvanz/policies/testing-sigstore-localinfra:latest
2025-11-10T19:23:35.965221Z  INFO kwctl::verify: Policy successfully verified

```


## Additional Information

@kravciak @juadk , the scaffolding repository has a github [action](https://github.com/sigstore/scaffolding/tree/d0a102b3edf322c9658c0e5abe94a671f49e8245/actions) able to spin up a sigstore containers to allow testing on CI as well. 